### PR TITLE
Replace dumb quotes with smart quotes

### DIFF
--- a/lexicon/1.2.json
+++ b/lexicon/1.2.json
@@ -4,7 +4,7 @@
         "refers": "General Demonstrative Root",
         "stems": [
             {
-                "BSC": "(to be) \"this / the one at-hand / the one in question\" referring to entities, situations, abstract notions, etc. (depending on the CA complex); [STA:] to be this/what is under discussion / [DYN:] to do this/what is under discussion",
+                "BSC": "(to be) “this / the one at-hand / the one in question” referring to entities, situations, abstract notions, etc. (depending on the CA complex); [STA:] to be this/what is under discussion / [DYN:] to do this/what is under discussion",
                 "CTE": "(to be) that which is the essence or essential point or meaning of this/what is at-hand",
                 "CSV": "(to be) that which is the form/structure or physical manifestation of this/what is at-hand",
                 "OBJ": "(to be) the object/entity/situation/idea, etc. being referred to by this/what is under discussion or at-hand"
@@ -12,6 +12,6 @@
             "that (one), near, at, by or associated w/ addressee",
             "that (one yonder), not near, at, by or associated with either speaker or addressee"
         ],
-        "notes": "Stem Zero: \"this / the one at-hand / the one in question\".\n\nUsing various noun cases and other morphology, the above root provides translations for phrases such as \"thus\"/\"in this/that manner\", \"there\"/\"in that place/location\", \"Yes\"/\"It is that\", \"No\"/\"It is not that\", \"some / some of that\", etc."
+        "notes": "Stem Zero: “this / the one at-hand / the one in question”.\n\nUsing various noun cases and other morphology, the above root provides translations for phrases such as “thus”/“in this/that manner”, “there”/“in that place/location”, “Yes”/“It is that”, “No”/“It is not that”, “some / some of that”, etc."
     }
 ]

--- a/lexicon/2.0.json
+++ b/lexicon/2.0.json
@@ -4,7 +4,7 @@
     "refers": "HAPPEN / OCCUR(ENCE) / MANIFEST / EVENT",
     "stems": [
       {
-        "BSC": "(to be) an occurrence of something; to happen / occur / take place / transpire / to \"pass\" [both the content/nature of the event and its transpiring",
+        "BSC": "(to be) an occurrence of something; to happen / occur / take place / transpire / to “pass” [both the content/nature of the event and its transpiring",
         "CTE": "(to be) a state of something occurring/transpiring of an act/event/state",
         "CSV": "(to be) an act of (causing) something to happen/occur",
         "OBJ": "(to be) that which happens/occurs/transpires"
@@ -55,7 +55,7 @@
       "(to be) an act of practicing; to practice CPT = be proficient at; have proficiency in",
       "(to be) a source of knowledge, a resource from which facts can be learned, a knowledge base"
     ],
-    "notes": "\\* This stem signifies learning from static knowledge sources (e.g., books/documents and/or personal research; for learning from a teacher, see **-DDY-** \"TEACHING ↔ BEING A STUDENT\""
+    "notes": "\\* This stem signifies learning from static knowledge sources (e.g., books/documents and/or personal research; for learning from a teacher, see **-DDY-** “TEACHING ↔ BEING A STUDENT”"
   },
   {
     "root": "LŢT",
@@ -154,7 +154,7 @@
       "(to be) an instance/act of forming or fashioning something via a combination of ingredients, e.g., cooking, mixing together, combining melodies from instruments to make music, tinkering with a variety of parts, etc.",
       "(to be) an instance/act of bringing something into being via organizing disparate parts into a coherent whole"
     ],
-    "notes": "Associated Affix: ***MAK***\n\n(NOTE: This root does not refer to \"make/create\" meaning \"emit/secrete/produce\" as in \"make noise\" or \"make milk\", etc.)"
+    "notes": "Associated Affix: ***MAK***\n\n(NOTE: This root does not refer to “make/create” meaning “emit/secrete/produce” as in “make noise” or “make milk”, etc.)"
   },
   {
     "root": "ŘŢK",
@@ -222,7 +222,7 @@
         "CSV": "(to be) the act/process of choosing from one's available options/alternatives",
         "OBJ": "(to be) the choice made; to be the entity/alternative/option chosen or selected"
       },
-      "(to be) an act/process of \"weighing\"/pondering of a choice; conduct a pro-vs.-con analysis",
+      "(to be) an act/process of “weighing”/pondering of a choice; conduct a pro-vs.-con analysis",
       "(to be) an state/act of settling for something (i.e., reluctant choice to avoid the alternative)"
     ]
   },
@@ -458,13 +458,13 @@
     "refers": "WONDERING",
     "stems": [
       {
-        "BSC": "(to be) a state/act of wondering about something that is potentially knowable; to wonder about something [i.e., desire to know something that can (presumably/theoretically) be known, e.g., \"I wonder what papaya tastes like\", \"I wonder if she is religious.\"]",
+        "BSC": "(to be) a state/act of wondering about something that is potentially knowable; to wonder about something [i.e., desire to know something that can (presumably/theoretically) be known, e.g., “I wonder what papaya tastes like”, “I wonder if she is religious.”]",
         "CTE": "(to be in) a state of wondering, i.e., the desire to know something that can (presumably/theoretically) be known",
         "CSV": "(to be) the act/process of asking oneself (either verbally or in one's thoughts) something which one desires to know that can (presumably/theoretically) be known; to ask oneself such a question",
         "OBJ": "(to be) what one wonders about"
       },
-      "(to be) a state act of wondering about something no longer knowable; to wonder about something [i.e., desire to know something that (presumably/theoretically) can no longer be known, e.g., \"I wonder what cooked dinosaur tasted like\", \"I wonder what Newton would think of quantum theory.\"]",
-      "(to be) a state/act of wondering about something not yet knowable [i.e., desire to know something unknowable until some future time, e.g., \"I wonder if I'll ever be able to walk again\", \"I wonder if humankind will ever colonize another planet.\"]"
+      "(to be) a state act of wondering about something no longer knowable; to wonder about something [i.e., desire to know something that (presumably/theoretically) can no longer be known, e.g., “I wonder what cooked dinosaur tasted like”, “I wonder what Newton would think of quantum theory.”]",
+      "(to be) a state/act of wondering about something not yet knowable [i.e., desire to know something unknowable until some future time, e.g., “I wonder if I'll ever be able to walk again”, “I wonder if humankind will ever colonize another planet.”]"
     ]
   },
   {
@@ -552,12 +552,12 @@
     "refers": "PREPARATION / PRELIMINARY MEASURE / READINESS",
     "stems": [
       {
-        "BSC": "(to be) a state/act of preparation (for something); to prepare (for something) [i.e., to take steps or measures that make one (more) ready to deal with something] (CPT version = \"state of readiness; be ready\") ",
+        "BSC": "(to be) a state/act of preparation (for something); to prepare (for something) [i.e., to take steps or measures that make one (more) ready to deal with something] (CPT version = “state of readiness; be ready”) ",
         "CTE": "(to be) state of desire to prepare [CPT version = preparedness/readiness] ",
         "CSV": "(to be) a physical act of preparation; to do something that prepares an entity for something ",
         "OBJ": "(to be) what one is preparing for"
       },
-      "(to be) a state/act of establishing preliminary measures necessary for something else to occur; to perform a preliminary step/task/measure, \"lay the groundwork for\", \"lay a foundation for\" ",
+      "(to be) a state/act of establishing preliminary measures necessary for something else to occur; to perform a preliminary step/task/measure, “lay the groundwork for”, “lay a foundation for” ",
       "(to be) a state/act of preparing/readying something, putting something together, assembling, making something ready for use or consumption; to prepare/ready something for use (e.g., food, a tent, wood in a fireplace, a painter's palette, a surgeon's operating room, etc.)"
     ]
   },
@@ -677,7 +677,7 @@
         "BSC": "(to be) something good ( = materially beneficial to the context at hand) [both the act/event/situation and its beneficent quality]",
         "CTE": "(to be) the essential state/quality of material goodness/beneficence manifested in a particular act/state/event/situation/entity, etc.",
         "CSV": "(to be) a particular act/state/event/situation/entity, etc. identified as being good; to do something materially/tangibly good/beneficial",
-        "OBJ": "(to be) the particular element(s) (e.g., word(s), action(s), emanation(s), appearance, product, presence of something, lack of something, etc.) which makes something describable/identifiable as being materially/tangibly \"good/beneficial\""
+        "OBJ": "(to be) the particular element(s) (e.g., word(s), action(s), emanation(s), appearance, product, presence of something, lack of something, etc.) which makes something describable/identifiable as being materially/tangibly “good/beneficial”"
       },
       "(to be) something good [ = morally right; beneficial in a metaphysical sense]",
       "(to be) something good [ = advantageous or effective]"
@@ -708,7 +708,7 @@
         "OBJ": "(to be) that to/for which energy is being used/exerted"
       },
       "(to be) an instance/manifestation of action or effort; to act, to perform, to do, make an effort (i.e., energy expenditure focused on a specific task)",
-      "(to be) an act/state of an entity operating or functioning or \"working\" (i.e., the proper or expected functioning of a device or machine or process as in \"Does the washing machine work?\"); to operate, to function"
+      "(to be) an act/state of an entity operating or functioning or “working” (i.e., the proper or expected functioning of a device or machine or process as in “Does the washing machine work?”); to operate, to function"
     ]
   },
   {
@@ -741,7 +741,7 @@
   },
   {
     "root": "ÇD",
-    "refers": "IMPRESSION / APPEARANCE / \"LOOK\" / SEMBLANCE / ASPECT / GUISE",
+    "refers": "IMPRESSION / APPEARANCE / “LOOK” / SEMBLANCE / ASPECT / GUISE",
     "stems": [
       {
         "BSC": "(to be) an impression; to give off an impression (i.e., to incite a reaction or belief in another based upon one's appearance/behavior/words/actions, etc., whether intentionally or not)",
@@ -749,7 +749,7 @@
         "CSV": "(to be) an act/state of giving off/creating an impression to another",
         "OBJ": "(to be) the entity/person/party who gives off an impression or whom one has an impression about"
       },
-      "(to be) the appearance or \"look\" or semblance or aspect of an entity [i.e., the outward subjective impression upon on observer given off by one's visual dress, physique, manner]; to appear, to look [ = have the appearance/look/semblance/aspect of]",
+      "(to be) the appearance or “look” or semblance or aspect of an entity [i.e., the outward subjective impression upon on observer given off by one's visual dress, physique, manner]; to appear, to look [ = have the appearance/look/semblance/aspect of]",
       "(to be) the guise of an entity; to be in the guise of, have the guise of"
     ]
   },
@@ -873,7 +873,7 @@
         "BSC": "(to be) a state/instance of coinciding, a coincidence; to coincide [not necessarily simultaneous but auspiciously timed in relation to another event]",
         "CTE": "(to be) a state of coincidence",
         "CSV": "(to be) an act which constitutes a coincidence; to do something that creates/constitutes a coincidence (with something else)",
-        "OBJ": "(to be) the other \"half\" of a coincidence, the other coinciding event/entity or circumstance"
+        "OBJ": "(to be) the other “half” of a coincidence, the other coinciding event/entity or circumstance"
       },
       "(to be) a state/instance of simultaneity; to occur simultaneously without knowledge/awareness of the other state/event occurring at the same time",
       "(to be) a state/instance of synchronicity (i.e., a coincidence so unlikely but nevertheless having significant personal impact on a situation, that one can only marvel and/or be suspicious of its occurrence)"
@@ -1028,7 +1028,7 @@
       "(to be) a riddle (i.e., a word-based recreational puzzle usually designed to be witty on its initial face)",
       "(to be) charade (i.e., a recreational puzzle acted out in real-time)"
     ],
-    "notes": "Derivation: \"maze\" = Stem 1 above plus the Type-2 concatenated stem for \"pathway/trail\""
+    "notes": "Derivation: “maze” = Stem 1 above plus the Type-2 concatenated stem for “pathway/trail”"
   },
   {
     "root": "ZJ",
@@ -1041,7 +1041,7 @@
         "OBJ": "(to be) what is (to be) concealed"
       },
       "(to be) a state/act of concealing/hiding/masking something; act of concealment; to conceal/hide/mask [i.e., by masking, covering up, disguising, enclosing so as not to be directly observed, etc.]",
-      "(to be) a state/act of secrecy; to keep something secret [OBJ Specification = \"a secret\"]"
+      "(to be) a state/act of secrecy; to keep something secret [OBJ Specification = “a secret”]"
     ]
   },
   {
@@ -1083,7 +1083,7 @@
         "CSV": "(to be) a physical act of making/fashioning a linear indentation/groove/channel",
         "OBJ": "(to be) an implement for use with or placement into a linear indentation/groove/channel"
       },
-      "(to be) a slot; to make a slot (i.e., a linear opening into which something can be placed/fitted; does NOT mean \"slot\" in a classificatory/schematic sense as in \"Can we be slotted in between those appointments?\" or \"The morpho-phonology of the Ithkuil formative has a slot structure.\")",
+      "(to be) a slot; to make a slot (i.e., a linear opening into which something can be placed/fitted; does NOT mean “slot” in a classificatory/schematic sense as in “Can we be slotted in between those appointments?” or “The morpho-phonology of the Ithkuil formative has a slot structure.”)",
       "(to be) a furrow"
     ]
   },
@@ -1140,7 +1140,7 @@
         "OBJ": "(to be) that which is shapely/well-formed/well-proportioned"
       },
       "(to be) a state of something being aesthetically/sensually pleasing or satisfying (e.g., a fine meal, a glass of wine, a thrill ride, a sexual experience, etc.); to experience a sense of aesthetic/sensual satisfaction/pleasure from something",
-      "(to be) a state of something being stylish/fine (as in a \"finely\"-made, \"finely\"-crafted); to be/make something stylish/fine, etc."
+      "(to be) a state of something being stylish/fine (as in a “finely”-made, “finely”-crafted); to be/make something stylish/fine, etc."
     ]
   },
   {
@@ -1176,7 +1176,7 @@
     "refers": "INTENSIFICATION / AMELIORATION / IMPROVEMENT / AGGRAVATION / WORSENING",
     "stems": [
       {
-        "BSC": "(to be) a state/act of intensifying/\"heightening\"; to intensify/\"heighten\" (i.e., make the effect of something stronger or more effective/impactful)",
+        "BSC": "(to be) a state/act of intensifying/“heightening”; to intensify/“heighten” (i.e., make the effect of something stronger or more effective/impactful)",
         "CTE": "(to be) a state of intensification",
         "CSV": "(to be) an act of intensifying; to do something that causes intensification",
         "OBJ": "(to be) that which is intensified"
@@ -1345,7 +1345,7 @@
     "refers": "RIDE / DRIVE / TRANSPORT / PASSENGER",
     "stems": [
       {
-        "BSC": "(to be) a state/act of riding/drive; to ride/drive (i.e., to operate/control a mechanical device, machine, or animal as a means of conveyance/transportation, e.g., a bike, a horse, an automobile) [NOTE: this stem does not mean \"ride\" where one is simply being conveyed without being the controller/operator, e.g., ride a bus]",
+        "BSC": "(to be) a state/act of riding/drive; to ride/drive (i.e., to operate/control a mechanical device, machine, or animal as a means of conveyance/transportation, e.g., a bike, a horse, an automobile) [NOTE: this stem does not mean “ride” where one is simply being conveyed without being the controller/operator, e.g., ride a bus]",
         "CTE": "(to be) a state of riding/driving something (i.e., operating the means of conveyance/transportation)",
         "CSV": "(to be) an act of driving/riding (i.e., operating/controlling) a means of personal conveyance/transportation; to perform the physical act(s) of riding/driving something (e.g., a horse, bike, automobile, skateboard, etc.)",
         "OBJ": "(to be) the person being conveyed/transported, the transportee"
@@ -1380,7 +1380,7 @@
         "OBJ": "(to be) what is (being / to be) washed"
       },
       "(to be) a state/act of bathing; to bathe",
-      "(to be) a state/act of rinsing/flushing/showering; to rinse/flush/shower (NOTE: by \"shower\" is meant use of a controlled spray of water/cleansing fluid, not a rainshower or naturally occurring spray/pouring of water/liquid)"
+      "(to be) a state/act of rinsing/flushing/showering; to rinse/flush/shower (NOTE: by “shower” is meant use of a controlled spray of water/cleansing fluid, not a rainshower or naturally occurring spray/pouring of water/liquid)"
     ]
   },
   {
@@ -1406,12 +1406,12 @@
         "BSC": "(be) a (state/process of) implication [i.e., a state/situation which functions as evidence by which an observer may deduce/infer something; to imply something]",
         "CTE": "(be) an implication; that which is implied",
         "CSV": "(be) a process of implying; offer/manifest evidence from which an inference can be made",
-        "OBJ": "(be) that which gives rise to, or is the basis for an implication; a hint, a \"tip\""
+        "OBJ": "(be) that which gives rise to, or is the basis for an implication; a hint, a “tip”"
       },
       "(process of) connotation; to connote",
       "(process of) allusion; to allude (to)"
     ],
-    "notes": "This root is also used as the **IMPLICATIVE (IPL) Bias affix**: = *\"of course,\" \"after all,\" or \"needless to say\"*"
+    "notes": "This root is also used as the **IMPLICATIVE (IPL) Bias affix**: = *“of course,” “after all,” or “needless to say”*"
   },
   {
     "root": "ÇÇK",
@@ -1424,9 +1424,9 @@
         "OBJ": "(be) the entity which in a maximal state"
       },
       "(be at) the optimal point/stage/degree/condition/state",
-      "(be at) the supreme/utmost/\"highest\"/foremost point/stage/degree/state"
+      "(be at) the supreme/utmost/“highest”/foremost point/stage/degree/state"
     ],
-    "notes": "This root is also used as the **OPTIMAL (OPT) Bias affix**: = prolonged \"so\" or \"totally\" as in *\"I so don't care!\"* or *\"That is totally what I wanted.\"*"
+    "notes": "This root is also used as the **OPTIMAL (OPT) Bias affix**: = prolonged “so” or “totally” as in *“I so don't care!”* or *“That is totally what I wanted.”*"
   },
   {
     "root": "LXL",
@@ -1469,7 +1469,7 @@
       "(to be) an act/process of exposure, i.e., letting others observe/discern something they otherwise would not observe/discern",
       "(to be) an advertisement; to advertise"
     ],
-    "notes": "This root is also used as the **ANNUNCIATIVE (ANN) Bias Affix**: = *\"Guess what!\"* or *\"Wait till you hear this!\"*"
+    "notes": "This root is also used as the **ANNUNCIATIVE (ANN) Bias Affix**: = *“Guess what!”* or *“Wait till you hear this!”*"
   },
   {
     "root": "ŢRR",
@@ -1526,7 +1526,7 @@
       "(to be/manifest a) degree of suitability / fitness / propriety / effectiveness ( = best choice for the context at hand)",
       "(to be/manifest a) degree of legitimacy/orthodoxy ( = adherence to legal / ritualistic / societal conventions)"
     ],
-    "notes": "Affix: **ERR** (use SUF/EXN/EXD, etc.)\n\nThis root is also used as the **CORRECTIVE (CRR) Bias Affix**: *\"that is to say…,\" \"What I mean(t) to say is…\" \"I mean….\"* "
+    "notes": "Affix: **ERR** (use SUF/EXN/EXD, etc.)\n\nThis root is also used as the **CORRECTIVE (CRR) Bias Affix**: *“that is to say…,” “What I mean(t) to say is…” “I mean….”* "
   },
   {
     "root": "ŘḐ",
@@ -1568,7 +1568,7 @@
         "CSV": "(to be) a degree/extent ( = the amount of effect/impact/capacity)",
         "OBJ": "(to be) the entity/party affected/impacted by the degree/extent of something"
       },
-      "(to be) the range of something ( = measure of the \"upper\" or \"outer\" limit of the effect/impact of something)",
+      "(to be) the range of something ( = measure of the “upper” or “outer” limit of the effect/impact of something)",
       "(to be) the intensity of something ( = measure of the strength of the effect/impact of something)"
     ],
     "notes": "Associated Affix: **EXN**"
@@ -1665,7 +1665,7 @@
         "CSV": "(to be) a state of consequentiality; a state of there being a consequence; to manifest consequentiality",
         "OBJ": "(to be) an entity/party from which arises a consequence"
       },
-      "(to be/manifest a) result of something ( = a concrete/tangible \"product\" or specific/nameable abstract entity resulting from a state/act/event/occurrence)",
+      "(to be/manifest a) result of something ( = a concrete/tangible “product” or specific/nameable abstract entity resulting from a state/act/event/occurrence)",
       "(to be/manifest a) abstract result/outcome ( = an abstract set of non-preexisting circumstances arising out of an occurrence/event/act/state)"
     ],
     "notes": "Affix: **CNQ** (use SUF/EXN/EXD, etc. to specify degree)"
@@ -1681,7 +1681,7 @@
         "OBJ": "(to be) an entity/party impacted/affected by one's degree of conformity/typicalness"
       },
       "(to be/manifest a) degree of being commonplace / typical / run-of-the-mill; to typify to a particular degree, to be typical of to a particular degree",
-      "(to be/manifest a) degree of being original / innovative / \"out-of-the-box\""
+      "(to be/manifest a) degree of being original / innovative / “out-of-the-box”"
     ],
     "notes": "Affix: **TYP** (use SUF/EXN/EXD, etc. to specify degree)"
   },
@@ -1726,7 +1726,7 @@
         "OBJ": "(to be) an entity/party impacted/affected by one's degree of efficiency"
       },
       "(to be/manifest a) degree of adequacy ( = extent to which something serves sufficiently)",
-      "(to be/manifest a) degree of reward/value/ \"pay-off\"/ \"bang-for-the-buck\" ( = extent/value of return on investment of resources/effort/energy)"
+      "(to be/manifest a) degree of reward/value/ “pay-off”/ “bang-for-the-buck” ( = extent/value of return on investment of resources/effort/energy)"
     ],
     "notes": "Affix: **EFI** (use SUF/EXN/EXD, etc.)"
   },
@@ -1890,7 +1890,7 @@
         "CSV": "(to be) a degree of natural capacity/ability to",
         "OBJ": "(to be) an entity/party impacted/affected by one's degree of natural capacity/ability to"
       },
-      "(to be/manifest a) degree of natural talent / aptitude / \"gift\" for; be adept at",
+      "(to be/manifest a) degree of natural talent / aptitude / “gift” for; be adept at",
       "(to be/manifest a) degree of natural virtue ( = desired behavioral quality/characteristic/attribute)"
     ],
     "notes": "Affix: **TAL** (use SUF/EXN/EXD, etc.) "
@@ -1938,7 +1938,7 @@
       "(to be) a state/act of beginning, initiating, starting; to begin, to start, to initiate",
       "(to be) a state/act of causation; to cause (i.e., primary/direct, not secondary or enabling cause)"
     ],
-    "notes": "Affix: **OAU**\n\n* This root refers to origination, first-time occurrence, first-time causation only. For \"beginning/initiation\" meaning 'activate, start/initiate from a stopped/dormant state, or the commencement of a common/recurring/pre-arranged activity, see the root **-TĻ-**."
+    "notes": "Affix: **OAU**\n\n* This root refers to origination, first-time occurrence, first-time causation only. For “beginning/initiation” meaning 'activate, start/initiate from a stopped/dormant state, or the commencement of a common/recurring/pre-arranged activity, see the root **-TĻ-**."
   },
   {
     "root": "RÇN",
@@ -1988,7 +1988,7 @@
       "(to be/manifest a) an entry point, a point of ingress, an entry portal, entry gateway, a passageway by which to enter",
       "(to be/manifest a) an exit point, a point of egress, an exit portal, a passageway by which to exit"
     ],
-    "notes": "Affix: **ACS**\n\n\\* **NOTE**: The word for a \"door\" itself would be the BSC stem for \"access/passageway\" plus the MDF2/3 affix \"that which impedes/prevents X\", so that a \"door\" is literally a \"passage-impeding implement\". Consequently, one does not say \"open door\" in the language — one says \"unrestricted passageway\" or \"unrestricted doorway.\" "
+    "notes": "Affix: **ACS**\n\n\\* **NOTE**: The word for a “door” itself would be the BSC stem for “access/passageway” plus the MDF2/3 affix “that which impedes/prevents X”, so that a “door” is literally a “passage-impeding implement”. Consequently, one does not say “open door” in the language — one says “unrestricted passageway” or “unrestricted doorway.” "
   },
   {
     "root": "ŢD",
@@ -2024,7 +2024,7 @@
     "root": "VSKW",
     "stems": [
       "bag/sack",
-      "sealable plastic \"baggie\"",
+      "sealable plastic “baggie”",
       "satchel"
     ],
     "notes": "- **BSC**: (to be) an instance/act/state of containing/holding/keeping something in a container\n- **CTE**: (to be) the state of containment\n- **CSV**: (to be) the container itself\n- **OBJ**: (to be) that which is contained (via gravity); the content(s)"
@@ -2123,6 +2123,6 @@
       "(to be) the state/process of being/constituting an ingredient within a larger whole [i.e., an entity which (theoretically) has/had an autonomous existence prior to being merged with the whole but is now imbued within /inseparable from the whole",
       "(to be) a state/act/process of being an instruction"
     ],
-    "notes": "For positionally-defined component parts of an entity or system (e.g., the \"front\", \"back\", \"side\", \"bottom\" of an object), see Sec. 3.5."
+    "notes": "For positionally-defined component parts of an entity or system (e.g., the “front”, “back”, “side”, “bottom” of an object), see Sec. 3.5."
   }
 ]

--- a/lexicon/2.1.1.json
+++ b/lexicon/2.1.1.json
@@ -28,7 +28,7 @@
     "refers": "CUT / STAB / CRACK / FISSURE",
     "stems": [
       {
-        "BSC": "(be) an act of cutting something with a (quasi-) bladed instrument or force (\"cut\" = to make a quasi-linear, parallel-to-the-surface break in the structural/cohesive integrity of the surface integument of an entity/object by means of a bladed (or bladelike) instrument)",
+        "BSC": "(be) an act of cutting something with a (quasi-) bladed instrument or force (“cut” = to make a quasi-linear, parallel-to-the-surface break in the structural/cohesive integrity of the surface integument of an entity/object by means of a bladed (or bladelike) instrument)",
         "CTE": "(be) the physical cut itself; a quasi-linear break in the structural/cohesive integrity of the surface integument of an entity/object",
         "CSV": "(be) the physical act/process of cutting; to cut",
         "OBJ": "(be) a blade (the portion of a knife/sword/axe/scissors, etc. that effectuates a cut)"
@@ -119,8 +119,8 @@
         "CSV": "(be) an act of piercing, puncturing",
         "OBJ": "(be) the appendage/implement/tool used for piercing, puncturing"
       },
-      "(be) an act of removing material by burrowing or tunneling* [Specification pattern is like Stem 2 of the root \"DIG\"]",
-      "(be) an act of leaving behind a hole, puncture, tunnel, i.e., an access point or passageway through a medium to another side or separate space [Specification pattern is like Stem 3 of the root \"DIG\"]"
+      "(be) an act of removing material by burrowing or tunneling* [Specification pattern is like Stem 2 of the root “DIG”]",
+      "(be) an act of leaving behind a hole, puncture, tunnel, i.e., an access point or passageway through a medium to another side or separate space [Specification pattern is like Stem 3 of the root “DIG”]"
     ]
   },
   {
@@ -146,7 +146,7 @@
         "OBJ": "(be) the medium/firmament in which a depression or concavity is made"
       }
     ],
-    "notes": "Use of the word \"hole\" in translating the stems of this root is within the narrow context of being a synonym for 'scooped-out depression/concavity within a 3-dimensional medium; it does not mean \"hole\" as an access point between two spaces or through some two- or 3-dimensional medium as in \"a hole in my jeans\" or \"a hole through the wall\" (use the root **-ẒF-** below instead).\n\nNOTE: Use the above root with the **SVS** affix to derive words for scoop, excavate and to derive words for \"drill\", \"bore\", \"cavern\". Combine it with other appropriate morphology to render the word for \"delve\" and \"worm one's way into\". "
+    "notes": "Use of the word “hole” in translating the stems of this root is within the narrow context of being a synonym for 'scooped-out depression/concavity within a 3-dimensional medium; it does not mean “hole” as an access point between two spaces or through some two- or 3-dimensional medium as in “a hole in my jeans” or “a hole through the wall” (use the root **-ẒF-** below instead).\n\nNOTE: Use the above root with the **SVS** affix to derive words for scoop, excavate and to derive words for “drill”, “bore”, “cavern”. Combine it with other appropriate morphology to render the word for “delve” and “worm one's way into”. "
   },
   {
     "root": "RẒČ",
@@ -172,10 +172,10 @@
         "CSV": "(be) an act of hollowing out or burrowing",
         "OBJ": "(be) the appendage/implement/device/machine used for hollowing/burrowing/tunneling"
       },
-      "(be) an act of removing material by hollowing out, burrowing or tunneling* [Specification pattern is like Stem 2 of the root \"DIG\"]",
-      "(be) an act of leaving behind a hollow, burrow or tunnel* [Specification pattern is like Stem 3 of the root \"DIG\"]"
+      "(be) an act of removing material by hollowing out, burrowing or tunneling* [Specification pattern is like Stem 2 of the root “DIG”]",
+      "(be) an act of leaving behind a hollow, burrow or tunnel* [Specification pattern is like Stem 3 of the root “DIG”]"
     ],
-    "notes": "This root refers to the creation of a tube-like space within a 3-dimensional medium; it does not necessarily imply that the tube-like space functions as a conduit or passageway to another separate space or medium -- thus, use of the translation \"tunnel\" here is in a limited context. If one wishes to signify a tunnel-like conduit connecting two separate spaces, use the root **-ẒF-** above instead. "
+    "notes": "This root refers to the creation of a tube-like space within a 3-dimensional medium; it does not necessarily imply that the tube-like space functions as a conduit or passageway to another separate space or medium -- thus, use of the translation “tunnel” here is in a limited context. If one wishes to signify a tunnel-like conduit connecting two separate spaces, use the root **-ẒF-** above instead. "
   },
   {
     "root": "GŢ",
@@ -196,7 +196,7 @@
     "refers": "FITTING / ACCOMMODATION / NICHE",
     "stems": [
       {
-        "BSC": "(be) an act/instance of one entity physically fitting into/with another so that one is \"carried\" along as the other moves/operates",
+        "BSC": "(be) an act/instance of one entity physically fitting into/with another so that one is “carried” along as the other moves/operates",
         "CTE": "(be) the state of fitting into another",
         "CSV": "(be) the physical act of fitting",
         "OBJ": "(be) the juncture itself which one establishes or seeks to establish by an act of fitting something into something else"
@@ -487,7 +487,7 @@
       "(be) an act/instance of driving into (i.e., forceful insertion or penetration through a resistant/hard surface by breaking/interrupting its surface integrity and passing into the resistant/hard three-dimensional volume beyond via pure force and quasi-violent breaking/distortion/displacement of the structural integrity of that volume",
       "(be) an act/instance of injection"
     ],
-    "notes": "This root refers only to the act/process of penetration of an external entity through a two-dimensional medium or into a three-dimensional medium; it is not focused on the resulting state of interiority itself. Thus, for translations of English words focused on the resulting state of interiority rather than the interruption of the surface integrity, e.g., \"insert, infuse, immerse, instill, imbue, implant\", use an appropriate SPATIO-TEMPORAL Root instead, e.g., **-XW-**, **-XL-**, **-CW-**, **-ŢP-**, **-ḐB-** and/or appropriate SpatioTemporal affixes associated with these roots."
+    "notes": "This root refers only to the act/process of penetration of an external entity through a two-dimensional medium or into a three-dimensional medium; it is not focused on the resulting state of interiority itself. Thus, for translations of English words focused on the resulting state of interiority rather than the interruption of the surface integrity, e.g., “insert, infuse, immerse, instill, imbue, implant”, use an appropriate SPATIO-TEMPORAL Root instead, e.g., **-XW-**, **-XL-**, **-CW-**, **-ŢP-**, **-ḐB-** and/or appropriate SpatioTemporal affixes associated with these roots."
   },
   {
     "root": "ŇÇ",
@@ -635,7 +635,7 @@
       "(be) an act/instance of initiating/activating something; to activate, to initiate, to start up (i.e., the act/process/procedure necessary to bring energy to a non-active state/entity so that it becomes active, e.g., starting a motor, activating a device, initiating a complex procedure, etc.)",
       "(be) an act/instance of instigation; to instigate (i.e., set in motion a series of events or arranging a precursor state/act/event that will lead to a specific outcome)"
     ],
-    "notes": "This root refers to \"beginning/initiation\" meaning 'activate, start/initiate from a stopped/dormant state, or the commencement of a common/recurring/pre-arranged activity; for the \"beginning/initiation\" meaning \"origination, first-time occurrence, first-time causation\", see the root **-ÇN-**."
+    "notes": "This root refers to “beginning/initiation” meaning 'activate, start/initiate from a stopped/dormant state, or the commencement of a common/recurring/pre-arranged activity; for the “beginning/initiation” meaning “origination, first-time occurrence, first-time causation”, see the root **-ÇN-**."
   },
   {
     "root": "PĻ",
@@ -803,7 +803,7 @@
         "OBJ": "(be) the material or substance (to be) applied"
       },
       "(be) an act/instance of applying/spreading/overlaying a gel-like substance or material to the surface of something; to apply, spread on (to), coat, smear a gel-like substance or material [CPT = foam up, froth]",
-      "(be) an act/instance of spraying a substance or medium onto another so that it is flush with, in complete contact with, or adheres to the underlying entity; to spray on, to apply via a spray(er) OBJ Specification = \"aerosol\""
+      "(be) an act/instance of spraying a substance or medium onto another so that it is flush with, in complete contact with, or adheres to the underlying entity; to spray on, to apply via a spray(er) OBJ Specification = “aerosol”"
     ]
   },
   {
@@ -955,7 +955,7 @@
         "OBJ": "(to be) the means/implement/procedure by which something is compressed/compacted/squeezed"
       },
       "(to be) a state/act of compression/compaction/concentration/ condensing; to compress, to compact, to concentrate, to condense [i.e., to fit a greater amount of a material, substance, content, into a fixed space via increasing its density per volume]",
-      "(to be) a state/act of energy storage; to store potential energy [OBJ = \"battery\"]"
+      "(to be) a state/act of energy storage; to store potential energy [OBJ = “battery”]"
     ]
   },
   {
@@ -1027,7 +1027,7 @@
       "(to be) an act/state of massaging with one's hand(s) or other body part",
       "(to be) an act/state of scratching with one's fingernails/claws or other sharp body part **"
     ],
-    "notes": "\\* for the sensation of being rubbed, massaged, or scratched, see **-VZW-**\n\n\\*\\* this stem refers only to scratching for grooming purposes or to relieve an itch; for the meaning of \"to make/leave a scratch or scratches in something\" see **-PPŠ-**"
+    "notes": "\\* for the sensation of being rubbed, massaged, or scratched, see **-VZW-**\n\n\\*\\* this stem refers only to scratching for grooming purposes or to relieve an itch; for the meaning of “to make/leave a scratch or scratches in something” see **-PPŠ-**"
   },
   {
     "root": "LŢR",
@@ -1095,7 +1095,7 @@
       "(be) a state of purity, being pure; be/make pure, purify, decontaminate, disinfect (i.e., to be/make free from foreign/invasive/polluting substances)",
       "(be) a state/act of proper sanitation/hygiene; be sanitary/hygienic, exercise proper sanitation/hygiene (i.e., practices which help to ensure an entity/party/environment remains clean or pure)"
     ],
-    "notes": "\\* This stem does not mean \"organize\" or \"de-clutter\" as in \"to clean a room\" — see the next root(-ŢB-) below."
+    "notes": "\\* This stem does not mean “organize” or “de-clutter” as in “to clean a room” — see the next root(-ŢB-) below."
   },
   {
     "root": "ŢB",
@@ -1194,7 +1194,7 @@
         "OBJ": "(be) that which is used to physically damage"
       },
       "(be) an act/instance of rendering less-than-fully operable/functional; corrupt, subvert, undermine [CPT Version = ruin, devastate, break up, destroy operationally, i.e., damage, corrupt, or subvert to the point of being unable to function/operate]",
-      "(be) an act/instance of reducing the presence/existence of; to reduce, lessen [CPT version = eradicate, eliminate, annihilate, \"disappear\", i.e., to render something nonexistent]"
+      "(be) an act/instance of reducing the presence/existence of; to reduce, lessen [CPT version = eradicate, eliminate, annihilate, “disappear”, i.e., to render something nonexistent]"
     ]
   },
   {

--- a/lexicon/3.1.json
+++ b/lexicon/3.1.json
@@ -137,13 +137,13 @@
     "refers": "PHYSICAL SPATIO-TEMPORAL EXTENSION",
     "stems": [
       {
-        "BSC": "(to be) a state/act of spatio-temporal extension linearly/unidimensionally (up/out/along/back, etc.) to a certain point/level/height, etc.; to extend in such a manner, to\"reach\" (to) a certain point/level/height, etc.",
+        "BSC": "(to be) a state/act of spatio-temporal extension linearly/unidimensionally (up/out/along/back, etc.) to a certain point/level/height, etc.; to extend in such a manner, to“reach” (to) a certain point/level/height, etc.",
         "CTE": "(to be) a state of extension / being extended unidimensionally",
         "CSV": "(to be) an act of spatio-temporal extension unidimensionally ",
-        "OBJ": "(to be) that which spatio-temporally extends or \"reaches\" unidimensionally to a particular point/level/height, etc."
+        "OBJ": "(to be) that which spatio-temporally extends or “reaches” unidimensionally to a particular point/level/height, etc."
       },
-      "(to be) a state of extension two-dimensionally (out/among/away, etc.) to a certain distance/edge/linear landmark/linear boundary, etc., \"reach\" (to) a certain ",
-      " (to be) a state of spatio-temporal extension three-dimensionally (out/among/away, etc.) to a certain distance/planar edge/planar landmark/planar boundary, etc., \"reach\" (to) a certain distance/planar edge/planar landmark/planar boundary, etc.; to extend/ \"reach\" three-dimensionally in such a manner "
+      "(to be) a state of extension two-dimensionally (out/among/away, etc.) to a certain distance/edge/linear landmark/linear boundary, etc., “reach” (to) a certain ",
+      " (to be) a state of spatio-temporal extension three-dimensionally (out/among/away, etc.) to a certain distance/planar edge/planar landmark/planar boundary, etc., “reach” (to) a certain distance/planar edge/planar landmark/planar boundary, etc.; to extend/ “reach” three-dimensionally in such a manner "
     ]
   },
   {
@@ -157,7 +157,7 @@
         "OBJ": " (to be) the particular physical level something or someone is positioned on"
       },
       "(to be in) a position on a particular floor/story of a building (e.g., be on the fifth floor/story of a hotel); be on a particular floor/story of a building",
-      " (to be in) a position on a particular abstract level/tier of a series of metaphorical/abstract tiers/levels of something (e.g., \"He plays at grandmaster level/tier when it comes to chess.\")"
+      " (to be in) a position on a particular abstract level/tier of a series of metaphorical/abstract tiers/levels of something (e.g., “He plays at grandmaster level/tier when it comes to chess.”)"
     ]
   },
   {

--- a/lexicon/3.4.json
+++ b/lexicon/3.4.json
@@ -17,7 +17,7 @@
     {
         "root": "Ḑ",
         "refers": "POSITION/LOCATION AT 0 / 0 / 0",
-        "notes": "\"right here\", at the center point of the observer's 3-dimensional spatial frame of reference",
+        "notes": "“right here”, at the center point of the observer's 3-dimensional spatial frame of reference",
         "see": "Ţ"
     },
     {
@@ -179,43 +179,43 @@
     {
         "root": "FK",
         "refers": "POSITION BETWEEN/AMIDST/AMONG [IN A QUASI-PLANAR CONTEXT]",
-        "notes": "e.g., \"among others in a crowded room\"",
+        "notes": "e.g., “among others in a crowded room”",
         "see": "Ţ"
     },
     {
         "root": "DK",
         "refers": "POSITION BETWEEN/AMONG [IN A LINEAR UNIDIMENSIONAL CONTEXT]",
-        "notes": "e.g., \"between two others in a queue\"",
+        "notes": "e.g., “between two others in a queue”",
         "see": "Ţ"
     },
     {
         "root": "TK",
         "refers": "INDEFINITE POSITION AMIDST/AMONG [IN A 3-DIMENSIONAL VOLUME]",
-        "notes": "e.g., \"among a sky full of balloonists\"",
+        "notes": "e.g., “among a sky full of balloonists”",
         "see": "Ţ"
     },
     {
         "root": "ḐD",
         "refers": "POSITION/STATE INTERTWINED/INTERMINGLED/INTERMIXED IN 2-DIMENSIONAL PLANAR CONTEXT [INDIVIDUAL COMPONENTS SEPARABLE/EXTRACTABLE]",
-        "notes": "e.g., \"red marbles amidst a tabletop covered with different colored marbles\"",
+        "notes": "e.g., “red marbles amidst a tabletop covered with different colored marbles”",
         "see": "Ţ"
     },
     {
         "root": "ḐB",
         "refers": "POSITION/STATE INTERTWINED/INTERMINGLED/INTERMIXED IN 3-DIMENSIONAL VOLUME [INDIVIDUAL COMPONENTS SEPARABLE/EXTRACTABLE]",
-        "notes": "e.g., \"red marbles within a jar full of different colored marbles\"",
+        "notes": "e.g., “red marbles within a jar full of different colored marbles”",
         "see": "Ţ"
     },
     {
         "root": "ḐV",
         "refers": "POSITION/STATE INTERTWINED/INTERMINGLED/INTERMIXED IN 2-DIMENSIONAL PLANAR CONTEXT [INDIVIDUAL COMPONENTS INSEPARABLE/PERMANENTLY COMBINED]",
-        "notes": "e.g., \"yellow paint spread onto a blue canvas to make a green area\"",
+        "notes": "e.g., “yellow paint spread onto a blue canvas to make a green area”",
         "see": "Ţ"
     },
     {
         "root": "ḐG",
         "refers": "POSITION/STATE INTERTWINED/INTERMINGLED/INTERMIXED IN 3-DIMENSIONAL VOLUME [INDIVIDUAL COMPONENTS INSEPARABLE/PERMANENTLY COMBINED]",
-        "notes": "e.g., \"sugar granules poured into a cup of coffee\"",
+        "notes": "e.g., “sugar granules poured into a cup of coffee”",
         "see": "Ţ"
     },
     {

--- a/lexicon/3.5.json
+++ b/lexicon/3.5.json
@@ -9,7 +9,7 @@
                 "CSV": "A/the (relative) spatial position/location which defines/delineates a part/section of an entity; to be a/the spatial position/location which defines/delineates a part/section of an entity",
                 "OBJ": "The entity of which the componential position is a part; to be the entity of which the componential part/section is a part"
             },
-            "Inalienable, inherent, inseparable \"built-in\" component part/section in relation to the whole",
+            "Inalienable, inherent, inseparable “built-in” component part/section in relation to the whole",
             "Alienable, separable, detachable component part/section in relation to the whole"
         ],
         "notes": "Affix: **S08**"
@@ -31,27 +31,27 @@
     },
     {
         "root": "ḐY",
-        "refers": "UPPER PART/\"HALF\" OF AN ENTITY [RELATIVE TO ITS TYPICAL ORIENTATION UNDER GRAVITY]",
+        "refers": "UPPER PART/“HALF” OF AN ENTITY [RELATIVE TO ITS TYPICAL ORIENTATION UNDER GRAVITY]",
         "see": "ŢF"
     },
     {
         "root": "ḐW",
-        "refers": "LOWER PART/\"HALF\" OF AN ENTITY [RELATIVE TO ITS TYPICAL ORIENTATION UNDER GRAVITY]",
+        "refers": "LOWER PART/“HALF” OF AN ENTITY [RELATIVE TO ITS TYPICAL ORIENTATION UNDER GRAVITY]",
         "see": "ŢF"
     },
     {
         "root": "XW",
-        "refers": "INTERIOR/INTERNAL VOLUME/\"INSIDE(S)\"/\"INNARDS\" OF AN ENTITY",
+        "refers": "INTERIOR/INTERNAL VOLUME/“INSIDE(S)”/“INNARDS” OF AN ENTITY",
         "see": "ŢF"
     },
     {
         "root": "CL",
-        "refers": "LINEAR UNI-DIMENSIONAL MIDDLE, CENTER [AS SEEN PARALLEL TO LONG AXIS OF ENTITY (OR HEIGHT-AXIS OF A \"TALL\" ENTITY)]",
+        "refers": "LINEAR UNI-DIMENSIONAL MIDDLE, CENTER [AS SEEN PARALLEL TO LONG AXIS OF ENTITY (OR HEIGHT-AXIS OF A “TALL” ENTITY)]",
         "see": "ŢF"
     },
     {
         "root": "CR",
-        "refers": "LINEAR UNI-DIMENSIONAL MIDDLE, CENTER [AS SEEN PERPENDICULAR TO LONG AXIS OF ENTITY (OR HEIGHT-AXIS OF A \"TALL\" ENTITY)]",
+        "refers": "LINEAR UNI-DIMENSIONAL MIDDLE, CENTER [AS SEEN PERPENDICULAR TO LONG AXIS OF ENTITY (OR HEIGHT-AXIS OF A “TALL” ENTITY)]",
         "see": "ŢF"
     },
     {
@@ -87,17 +87,17 @@
     },
     {
         "root": "XL",
-        "refers": "INTERIOR SURFACE/INTERNAL SURFACE/INSIDE SURFACE/\"WALL\" OF AN ENTITY",
+        "refers": "INTERIOR SURFACE/INTERNAL SURFACE/INSIDE SURFACE/“WALL” OF AN ENTITY",
         "see": "ŢF"
     },
     {
         "root": "XR",
-        "refers": "EXTERIOR/EXTERNAL SURFACE/\"OUTSIDE\"/\"SKIN\" OF AN ENTITY",
+        "refers": "EXTERIOR/EXTERNAL SURFACE/“OUTSIDE”/“SKIN” OF AN ENTITY",
         "see": "ŢF"
     },
     {
         "root": "XḐ",
-        "refers": "EXTERNAL POINT-LIKE OUTWARD FACING VERTEX/\"CORNER\" OF AN ENTITY",
+        "refers": "EXTERNAL POINT-LIKE OUTWARD FACING VERTEX/“CORNER” OF AN ENTITY",
         "see": "ŢF"
     },
     {
@@ -107,7 +107,7 @@
     },
     {
         "root": "XK",
-        "refers": "EXTERNAL QUASI-LINEAR JOINING OF SURFACES/\"SEAM\" OF AN ENTITY",
+        "refers": "EXTERNAL QUASI-LINEAR JOINING OF SURFACES/“SEAM” OF AN ENTITY",
         "see": "ŢF"
     },
     {
@@ -118,17 +118,17 @@
     },
     {
         "root": "ČḐ",
-        "refers": "INTERNAL POINT-LIKE INTERIOR VERTEX/\"CORNER\" OF AN ENTITY",
+        "refers": "INTERNAL POINT-LIKE INTERIOR VERTEX/“CORNER” OF AN ENTITY",
         "see": "ŢF"
     },
     {
         "root": "XḐR",
-        "refers": "EXTERNAL LINEAR OUTWARD-FACING \"CORNER\" EDGE OR \"CORNER\" SPACE OF ENTITY",
+        "refers": "EXTERNAL LINEAR OUTWARD-FACING “CORNER” EDGE OR “CORNER” SPACE OF ENTITY",
         "see": "ŢF"
     },
     {
         "root": "ČḐR",
-        "refers": "INTERNAL LINEAR INTERIOR \"CORNER\" EDGE OR \"CORNER\" SPACE OF AN ENTITY",
+        "refers": "INTERNAL LINEAR INTERIOR “CORNER” EDGE OR “CORNER” SPACE OF AN ENTITY",
         "see": "ŢF"
     }
 ]

--- a/lexicon/3.7.json
+++ b/lexicon/3.7.json
@@ -16,10 +16,10 @@
                 "OBJ": "(to be) that which occurs/passes during evening/nighttime hours"
             },
             {
-                "BSC": "(to be) a particular \"o'clock\"-time of the day as named by the hour [use numerical roots or affixes to specify the number of hours since midnight] (includes both the time and the event occurring then)",
-                "CTE": "(to be) the measuring/delineation of time as specified by a particular \"o'clock\"-time of day",
-                "CSV": "(to be) the state of being/occurring at a particular \"o'clock\"-time of day",
-                "OBJ": "(to be) the event which occurs at or is specified by a particular \"o'clock\"-time of day"
+                "BSC": "(to be) a particular “o'clock”-time of the day as named by the hour [use numerical roots or affixes to specify the number of hours since midnight] (includes both the time and the event occurring then)",
+                "CTE": "(to be) the measuring/delineation of time as specified by a particular “o'clock”-time of day",
+                "CSV": "(to be) the state of being/occurring at a particular “o'clock”-time of day",
+                "OBJ": "(to be) the event which occurs at or is specified by a particular “o'clock”-time of day"
             }
         ],
         "notes": "for specific times, e.g., 10:15 am and 34.3 seconds, use Stem 3 with appropriate numerical affix, followed by numerical stems with a COO affix plus the appropriate stems of the -RW- root declined in the PARTITIVE case. Alternatively, one may use numerical stems with the various degrees of the ELA affix."
@@ -32,9 +32,9 @@
                 "BSC": "(to be) a particular amount of elapsed time which something occurs/exists; for something to occur/exist lasting/during a particular amount of time [Stem 1 = a moment]",
                 "CTE": "(to be) the event(s) occurring during a particular amount of elapsed time",
                 "CSV": "(to be) the duration of elapsed time [regardless of what may occur/exist during that period]",
-                "OBJ": "(to be) the \"volume\" of spacetime during/in which something occurs/exists"
+                "OBJ": "(to be) the “volume” of spacetime during/in which something occurs/exists"
             },
-            "a \"while\"",
+            "a “while”",
             "a portion of a day"
         ],
         "notes": "Affix: **TD1**\n\nFor the meaning of the old FORMAL stems previously associated with this root, use the new root(-RW-)"
@@ -142,7 +142,7 @@
             "present event, entity, occurrence",
             "future event, entity, occurrence"
         ],
-        "notes": "Affix: **TPF**\n\nThe above stems may be used in spatial contexts as well, in which case English translations might differ depending on context, e.g., \"previous\", \"former\", \"once-\", \"one-time\", \"here\", \"...at hand\", \"there\", \"-to-come\", \"expected/awaited\", etc."
+        "notes": "Affix: **TPF**\n\nThe above stems may be used in spatial contexts as well, in which case English translations might differ depending on context, e.g., “previous”, “former”, “once-”, “one-time”, “here”, “...at hand”, “there”, “-to-come”, “expected/awaited”, etc."
     },
     {
         "root": "KM",
@@ -175,7 +175,7 @@
                 "OBJ": "(to be) the process which is divided up into steps/stages/phases"
             },
             "(to be) a degree/grade or point on a progressive/scalar gradient",
-            "(to be) a section, sub-unit, discernible/identifiable/differentiated \"stretch\" or portion of a progressively/successively structured entity/phenomenon"
+            "(to be) a section, sub-unit, discernible/identifiable/differentiated “stretch” or portion of a progressively/successively structured entity/phenomenon"
         ],
         "notes": "Affix: **STG**"
     },

--- a/lexicon/4.0.json
+++ b/lexicon/4.0.json
@@ -12,7 +12,7 @@
             "(to be) something one is considering/mulling/contemplating; to consider, mull, contemplate, take into account",
             "(to be) an act of reasoning; to reason, use one's intellect [= employ a strict process of integrating logic and experience when thinking/analyzing]"
         ],
-        "notes": "Derivations: ponder, deliberate/deliberation, contemplate, mull, concentrate, theory, hypothesis, judge, conclude/conclusion.\n\nThis root is also used as the **PROPOSITIVE (PPV) Bias Affix**: *\"what if...\" \"It could be that....\" \"Consider this: ...\" \"Posit the following: ...\" \"Assume for the sake of argument that....\"*"
+        "notes": "Derivations: ponder, deliberate/deliberation, contemplate, mull, concentrate, theory, hypothesis, judge, conclude/conclusion.\n\nThis root is also used as the **PROPOSITIVE (PPV) Bias Affix**: *“what if...” “It could be that....” “Consider this: ...” “Posit the following: ...” “Assume for the sake of argument that....”*"
     },
     {
         "root": "KSL",
@@ -35,7 +35,7 @@
                 "OBJ": "(to be) a rule of logic by which one conducts convergent/critical thinking/analysis"
             },
             "(to be) a state/act/process of divergent/creative thinking relying on imagination, inspiration, and creative instinct",
-            "(to be) a state/act/process of lateral thinking \"outside the box\" employing a synthesis of divergent thinking and convergent thinking"
+            "(to be) a state/act/process of lateral thinking “outside the box” employing a synthesis of divergent thinking and convergent thinking"
         ]
     },
     {
@@ -65,7 +65,7 @@
             "(to be) a piece of advice; to advise",
             "(to be) a recommendation; to recommend"
         ],
-        "notes": "This root is also used as the **SUGGESTIVE (SGS) Bias Affix**: *\"How about...\" \"We could...\" \"Might I suggest...\"*"
+        "notes": "This root is also used as the **SUGGESTIVE (SGS) Bias Affix**: *“How about...” “We could...” “Might I suggest...”*"
     },
     {
         "root": "ŇTÇ",

--- a/lexicon/4.1.json
+++ b/lexicon/4.1.json
@@ -52,7 +52,7 @@
                 "OBJ": "(to be) the entity/party to which/whom one (intends to) communicate linguistically; the (intended) audience/listener/hearer/reader/recipient of a linguistic communication"
             },
             "(to be) an instance/utterance of linguistic communication for rhetorical, inspirational, socially effective, or psychologically manipulative purposes",
-            "(to be) a phoneme or morpho-phonemic element/component of linguistic communication; to be a meaningful \"sound\" in one's spoken language (e.g., a vowel or consonant or syllable)"
+            "(to be) a phoneme or morpho-phonemic element/component of linguistic communication; to be a meaningful “sound” in one's spoken language (e.g., a vowel or consonant or syllable)"
         ]
     },
     {
@@ -65,7 +65,7 @@
                 "CSV": "(to be) the visual inscription or physical presence of something written (regardless of its communicative content)",
                 "OBJ": "(to be) the object/surface on which something is written/inscribed"
             },
-            "(to be) something authored in writing, written composition; to \"write\" = to author, to compose in writing",
+            "(to be) something authored in writing, written composition; to “write” = to author, to compose in writing",
             "(to be) a written/visual character/symbol/glyph/letter/emoji/ideogram, etc., used for written/visual communication"
         ],
         "notes": "For the meaning of the old FORMAL stems previously associated with this root, use the following new root(-ŇTY-)"
@@ -80,7 +80,7 @@
                 "CSV": "(to be) the visual inscription or physical presence of something documented (regardless of its communicative content)",
                 "OBJ": "(to be) the object/surface on which something is documented"
             },
-            "(to be) a \"page\" of writing, a \"page\" of a written work [\"page\" = visible formal interface for static written communication]",
+            "(to be) a “page” of writing, a “page” of a written work [“page” = visible formal interface for static written communication]",
             "(to be) a written grapheme/character/letter, etc., used in a language's [official] writing system; to write (down) letters/characters/graphemes from/in a language's writing system"
         ]
     },
@@ -123,7 +123,7 @@
                 "OBJ": "(to be) a formal/authorized/official sign/signal"
             },
             "(to be) a state/act of being a symbol, emblem, device, insignia, logo",
-            "(to be) a state/act of being a linguistically representational mark/symbol other than a character/letter/grapheme from a language; to be/write a linguistically representational mark/symbol other than a character/letter/grapheme from a language (e.g., an emoji, an arrow, the power-on/off symbol on a device, the outline of a raised hand indicating \"stop\", a red circle with diagonal bar indicating something prohibited, etc.)"
+            "(to be) a state/act of being a linguistically representational mark/symbol other than a character/letter/grapheme from a language; to be/write a linguistically representational mark/symbol other than a character/letter/grapheme from a language (e.g., an emoji, an arrow, the power-on/off symbol on a device, the outline of a raised hand indicating “stop”, a red circle with diagonal bar indicating something prohibited, etc.)"
         ]
     },
     {
@@ -187,7 +187,7 @@
         "refers": "LEAVETAKING / SAYING GOODBYE / FAREWELL",
         "stems": [
             {
-                "BSC": "(to be) a state/act of casual leavetaking, saying \"see you later\"; to casually take one's leave (until an expected and predictable meeting); to say \"bye\" or \"good night\" or 'see you [tomorrow, this weekend, next week, etc.), to bid one a casual/temporary goodbye until an expected, predictable, soon-to-come remeeting.",
+                "BSC": "(to be) a state/act of casual leavetaking, saying “see you later”; to casually take one's leave (until an expected and predictable meeting); to say “bye” or “good night” or 'see you [tomorrow, this weekend, next week, etc.), to bid one a casual/temporary goodbye until an expected, predictable, soon-to-come remeeting.",
                 "CTE": "(to be) a state of casual leavetaking",
                 "CSV": "(to be) an act of casually taking one's leave; the actual words/actions employed to casually take leave of someone; to say words of casual/temporary leavetaking",
                 "OBJ": "(to be) the party/entity to whom one directs one's casual/temporary goodbye"
@@ -218,7 +218,7 @@
                 "BSC": "(to be) a play on words, witty or clever use of words; to play on words, to say/write something witty/clever using wordplay",
                 "CTE": "(to be) what one says/writes that constitutes a play-on-words",
                 "CSV": "(to be) a physical act of saying/writing something that is a play-on-words; to physically speak/write such",
-                "OBJ": "(to be) the subject/topic/situation/allusion \"hidden\" in a play-on-words"
+                "OBJ": "(to be) the subject/topic/situation/allusion “hidden” in a play-on-words"
             },
             "(to be) a pun; make a pun",
             "(to be) a double-entendre; say/write/make a double-entendre"
@@ -243,12 +243,12 @@
         "refers": "TITLE / ROLE",
         "stems": [
             {
-                "BSC": "(to be) a title [plus the entity so titled] [here, \"title\" refers to a word or phrase acting as a name, as in the title of a book or work of art, etc.]",
+                "BSC": "(to be) a title [plus the entity so titled] [here, “title” refers to a word or phrase acting as a name, as in the title of a book or work of art, etc.]",
                 "CTE": "(to be) an entity having a title",
                 "CSV": "(to have) a name; to bear a name",
                 "OBJ": "(to be) the name that an entity has"
             },
-            "(to be) a title [plus the entity so titled] [here, \"title\" refers to a formal designation given a person indicating their societal/occupational role/function, as in \"Doctor\", \"Queen,\" \"President\", \"Deputy\", \"Minister\", \"Countess,\" etc.]",
+            "(to be) a title [plus the entity so titled] [here, “title” refers to a formal designation given a person indicating their societal/occupational role/function, as in “Doctor”, “Queen,” “President”, “Deputy”, “Minister”, “Countess,” etc.]",
             "(to be) a role [plus the entity carrying out the role] (i.e., a formally assigned functional niche or societal status, as in a role in a play, or a role in society, e.g., jester, Hamlet, yenta, amanuensis, matchmaker, femme fatale, scapegoat, etc."
         ]
     },
@@ -293,7 +293,7 @@
             "(act of) assurance/allegation; to assure that something is so based on intuition, speculation, hope, or in the (immediate) absence of evidence",
             "(process of) affirmation; to affirm/swear that something is so"
         ],
-        "notes": "For \"claim\" in the sense of a formal claim for legal relief/indemnification, see -RŇS-.\n\nThis root is also used as the **CONTENSIVE (CNV) Bias affix**: = *\"I'm telling you...\", \"I told you so!\", \"You see?!\"*"
+        "notes": "For “claim” in the sense of a formal claim for legal relief/indemnification, see -RŇS-.\n\nThis root is also used as the **CONTENSIVE (CNV) Bias affix**: = *“I'm telling you...”, “I told you so!”, “You see?!”*"
     },
     {
         "root": "TFL",
@@ -381,7 +381,7 @@
             "(to be) ingratiating",
             "(to be) obsequious, unctuous, sycophantic"
         ],
-        "notes": "This root is also used as the **EUPHEMISTIC (EUP) Bias Affix**: *\"Let's just say that....\" or \"Well, let me put it this way....\"*"
+        "notes": "This root is also used as the **EUPHEMISTIC (EUP) Bias Affix**: *“Let's just say that....” or “Well, let me put it this way....”*"
     },
     {
         "root": "LLM",
@@ -390,13 +390,13 @@
             {
                 "BSC": "(to be) one's own self (= one's own person as an object of reflection or reference), oneself; to be/act (as) oneself",
                 "CTE": "(to be) one's sense of self-awareness, i.e., the conscious subjective sense that one exists as an individual",
-                "CSV": "(to be) the physical body plus tangible/conscious beliefs, values, thoughts, ideas, drives, personal characteristics, etc.that one is consciously aware of about oneself that constitute the \"ingredients\" which make up one's sense of self",
+                "CSV": "(to be) the physical body plus tangible/conscious beliefs, values, thoughts, ideas, drives, personal characteristics, etc.that one is consciously aware of about oneself that constitute the “ingredients” which make up one's sense of self",
                 "OBJ": "(to be) a person/entity [as observed externally by others] having a conscious self"
             },
             "(to be) one's sense of identity, i.e., what one senses/believes/observes introspectively about oneself that makes one feel unique as compared to others; what one senses/believes about oneself that distinguishes oneself from others; to have a sense of identity [OBJ = one's identity as established by authorized means; i.e., how one is formally/authoritatively distinguished from others]",
             "(to be) one's personality, set of one's personality traits"
         ],
-        "notes": "This root is also used as the **RELECTIVE (RFL) Bias Affix**: *\"Look at it this way...\" \"As I see it,...\" \"In my opinion,...\" or \"From my point of view,....\"*"
+        "notes": "This root is also used as the **RELECTIVE (RFL) Bias Affix**: *“Look at it this way...” “As I see it,...” “In my opinion,...” or “From my point of view,....”*"
     },
     {
         "root": "CČ",
@@ -411,7 +411,7 @@
             "(to be) an act/instance of humility/humbleness; be humble (i.e., behaving/being with a conscious sense of one's own defects or shortcomings, so that one is unassertive",
             "(to be) an act/instance of meekness; be meek (i.e., patient and mild in character/personality and not inclined to anger or resentment)"
         ],
-        "notes": "This root is also used as the **DIFFIDENT (DFD) Bias Affix**: *\"sorry, but...\" \"It's nothing. It's just...\"*"
+        "notes": "This root is also used as the **DIFFIDENT (DFD) Bias Affix**: *“sorry, but...” “It's nothing. It's just...”*"
     },
     {
         "root": "ŽŽT",
@@ -426,7 +426,7 @@
             "(to be) something matter-of-fact, down-to-earth or prosaic (i.e., lacking in any features or characteristics or behavior which would cause one to infer or guess their nature, motives, meaning, intentions, etc.)",
             "(to be) something unoriginal and predictable (i.e., lacking in any original or innovative aspects)"
         ],
-        "notes": "This root is also used as the **PROSAIC (PSC) Bias Affix**: *\"Meh... (said in disappointment)\" \"How ordinary!\"*"
+        "notes": "This root is also used as the **PROSAIC (PSC) Bias Affix**: *“Meh... (said in disappointment)” “How ordinary!”*"
     },
     {
         "root": "ḐXW",
@@ -455,7 +455,7 @@
             "(to be) an act/instance of abandonment; to abandon",
             "(to be) a act/instance of resignation (i.e., officially vacating one's role, duty, job)"
         ],
-        "notes": "This root is also used as the **RENUNCIATIVE (RNC) Bias Affix**: *\"So much for...!\" \"There goes...!\"*"
+        "notes": "This root is also used as the **RENUNCIATIVE (RNC) Bias Affix**: *“So much for...!” “There goes...!”*"
     },
     {
         "root": "RMSF",
@@ -480,7 +480,7 @@
             "(be) an act/process of urging/begging/imploring/ beseeching/entreating, i.e., an emotionally earnest/intense form of solicitation; to beseech, entreat, beg, insist",
             "(be) an act of prayer; to pray (i.e., to a deity or supernatural entity)"
         ],
-        "notes": "This root is also used as the **SOLICITATIVE (SOL) Bias Affix**: *\"please\"*"
+        "notes": "This root is also used as the **SOLICITATIVE (SOL) Bias Affix**: *“please”*"
     },
     {
         "root": "RŇS",
@@ -490,7 +490,7 @@
             "(be) an act/process of suing; to sue, file a (law)suit",
             "(be) an act/process of appealing; to appeal (i.e., to seek reversal of some punishment meted)"
         ],
-        "notes": "For \"claim\" in the sense of \"to assert (something) as being true\", see -RRJ-.",
+        "notes": "For “claim” in the sense of “to assert (something) as being true”, see -RRJ-.",
         "see": "ŇŇS"
     },
     {
@@ -506,7 +506,7 @@
             "(to be) something witty (i.e., subtly and cleverly humorous which strikes an audience as charming); to be witty",
             "(to be) something farcical or sardonic (i.e., something humorous in a double-edged manner based in irony or sarcasm); to be a farce, to be farcical"
         ],
-        "notes": "This root is also used as the **COMEDIC (CMD) Bias Affix: — -pļļ** *\"Funny!\" \"LOL\"*"
+        "notes": "This root is also used as the **COMEDIC (CMD) Bias Affix: — -pļļ** *“Funny!” “LOL”*"
     },
     {
         "root": "RPĻĻ",
@@ -563,7 +563,7 @@
             "(to be) an act/instance of disclosing or revealing something (i.e., let others see/know something which has previously not been seen by or known to them)",
             "(to be) a act/instance of admitting to something; to admit to, grant that something is so (i.e., acquiesce to allowing others to know of one's awareness of, association with, or involvement in something)"
         ],
-        "notes": "This root is also used as the **ADMISSIVE (ADM) Bias Affix**: *\"mm-hmm\" \"uh-huh\", \"I see\"*."
+        "notes": "This root is also used as the **ADMISSIVE (ADM) Bias Affix**: *“mm-hmm” “uh-huh”, “I see”*."
     },
     {
         "root": "LĻW",
@@ -611,7 +611,7 @@
                 "BSC": "(to be) a sexual/romantic relationship between two or more parties; to have a sexual/romantic relationship with another party or parties",
                 "CTE": "(to be) the psychological/emotional state of being in a sexual/romantic relationship",
                 "CSV": "(to be) a physical act/manifestation of a sexual/romantic relationship",
-                "OBJ": "(to be) one's sexual/romantic partner/\"lover\", boyfriend/girlfriend, significant other"
+                "OBJ": "(to be) one's sexual/romantic partner/“lover”, boyfriend/girlfriend, significant other"
             },
             "(to be) an act of sexual relations; to have sex, engage in sex(ual activity)",
             "(to be) an act of pursuing a sexual/romantic relationship; to pursue a sexual/romantic relationship; to date / to court"
@@ -729,7 +729,7 @@
                 "OBJ": "(to be) what one does that constitutes ministry/tending to"
             },
             "(to be) a state/act of patronage, sustenance or subsidization; to grant one's patronage, to subsidize",
-            "(to be) a state/act of endorsing, championing, rallying, garnering support for something/someone; to endorse, to champion, to rally/garner support for something/someone [Stem 3 + MTA/1 affix = \"propagandize\"]"
+            "(to be) a state/act of endorsing, championing, rallying, garnering support for something/someone; to endorse, to champion, to rally/garner support for something/someone [Stem 3 + MTA/1 affix = “propagandize”]"
         ]
     },
     {
@@ -952,7 +952,7 @@
             "(to be) a preference/inclination; to lean toward, be inclined to (choose something over something else), to favor, to prefer something (over something else)",
             "(to be) an aptness for / a proneness to; to be apt to, to be prone to"
         ],
-        "notes": "For \"preference/inclination\" in the sense of one's tastes/proclivities, see the root(-JKF-)."
+        "notes": "For “preference/inclination” in the sense of one's tastes/proclivities, see the root(-JKF-)."
     },
     {
         "root": "JKY",
@@ -1009,7 +1009,7 @@
             "(to be) an act of sending something to a destination or recipient / sending for delivery to a destination or intended recipient; to send something",
             "(to be) an act of bringing something to a destination or recipient / bringing as a delivery to a destination or intended recipient; to bring something"
         ],
-        "notes": "Similar to the root -N- but is focused on the physical conveyance/transferral to a destination, rather than the participatory \"roles\" of giver/receiver'"
+        "notes": "Similar to the root -N- but is focused on the physical conveyance/transferral to a destination, rather than the participatory “roles” of giver/receiver'"
     },
     {
         "root": "DV",
@@ -1087,7 +1087,7 @@
             },
             {
                 "BSC": "(to be) an act/process of financial accounting; to financially account [i.e., an accurate economic evaluation of (one's) material/financial assets",
-                "CTE": "(to be) one's monetary state/situation, how one is \"set\" for money; to have or be in a particular monetary situation (i.e., the extent/degree to which one is able to afford day-to-day and other expenses)",
+                "CTE": "(to be) one's monetary state/situation, how one is “set” for money; to have or be in a particular monetary situation (i.e., the extent/degree to which one is able to afford day-to-day and other expenses)",
                 "CSV": "(to be) a physical act/process of accounting/arithmetically figuring out one's (or another's) financial state/situation; to engage in a process of accounting",
                 "OBJ": "(to be) one's personal funds or monetary assets/the amount of money and other financial assets one owns"
             }
@@ -1168,7 +1168,7 @@
         "refers": "DESERVE / WORTHINESS / MERIT / RECOMPENSE / REPARATION",
         "stems": [
             {
-                "BSC": "(to be) a state of being deserving of something; to deserve/warrant/bear/be worth something (as in \"This bears worth looking into\", \"Your attitude warrants investigation\", \"Her application is worth considering\".)",
+                "BSC": "(to be) a state of being deserving of something; to deserve/warrant/bear/be worth something (as in “This bears worth looking into”, “Your attitude warrants investigation”, “Her application is worth considering”.)",
                 "CTE": "(to be) a state of deserving",
                 "CSV": "(to be) a physical act of demonstrating one deserves something; to do/say something that demonstrates that one deserves something",
                 "OBJ": "(to be) what one is or has done that warrants one's deserving something"
@@ -1263,16 +1263,16 @@
     },
     {
         "root": "VẒ",
-        "refers": "SUBJECTIVE INTERPRETATION / \"READING\"",
+        "refers": "SUBJECTIVE INTERPRETATION / “READING”",
         "stems": [
             {
-                "BSC": "(to be) a state/act of \"reading\" (i.e., interpreting) clues/signs/evidence (e.g., the clouds in the sky for a coming storm, footprints, animal tracks, a crime scene, etc.)",
+                "BSC": "(to be) a state/act of “reading” (i.e., interpreting) clues/signs/evidence (e.g., the clouds in the sky for a coming storm, footprints, animal tracks, a crime scene, etc.)",
                 "CTE": "(to be) a state of subjective interpretation based on clues/signs/evidence",
-                "CSV": "(to be) an act of \"reading\"/interpreting clues/signs/evidence; to \"read\"/interpret clues/signs/evidence",
-                "OBJ": "(to be) the clue(s)/sign(s)/piece(s) of evidence one \"reads\"/interprets"
+                "CSV": "(to be) an act of “reading”/interpreting clues/signs/evidence; to “read”/interpret clues/signs/evidence",
+                "OBJ": "(to be) the clue(s)/sign(s)/piece(s) of evidence one “reads”/interprets"
             },
-            "(to be) a state/act of \"reading\" (i.e., interpreting) a subjective situation or subjective set of clues, e.g., \"reading\" a person's face, \"reading between the lines\", \"reading\" a social situation, etc.)",
-            "(to be) a state/act of \"reading\" (i.e., interpreting) signs/marks within a specific arcane branch of knowledge (e.g., read palms, read the stars, read the I-Ching or other arcane symbology, etc.)"
+            "(to be) a state/act of “reading” (i.e., interpreting) a subjective situation or subjective set of clues, e.g., “reading” a person's face, “reading between the lines”, “reading” a social situation, etc.)",
+            "(to be) a state/act of “reading” (i.e., interpreting) signs/marks within a specific arcane branch of knowledge (e.g., read palms, read the stars, read the I-Ching or other arcane symbology, etc.)"
         ]
     },
     {
@@ -1288,7 +1288,7 @@
             "(to be) a state/act/instance of translating; to create a translation of something, to translate",
             "(to be) an act of interpretation; to interpret (i.e., act/function as skilled medium between an information source and its audience for purposes of making the source information comprehensible)"
         ],
-        "notes": "For \"interpret\" meaning 'ability to understand something by observation/analysis as in \"to interpret signs/clues\", see the root(-VẒ-)"
+        "notes": "For “interpret” meaning 'ability to understand something by observation/analysis as in “to interpret signs/clues”, see the root(-VẒ-)"
     },
     {
         "root": "RBR",
@@ -1329,7 +1329,7 @@
                 "OBJ": "(to be) one's opponent"
             },
             "(to be) a state/act of working openly against something or someone, openly acting inimically toward something or someone; to openly work against something or someone, be inimical toward something or someone",
-            "(to be) state/act of undermining something or someone (i.e., working secretly or underhandedly or 'behind one\"s back\" against their interests; to undermine something or someone"
+            "(to be) state/act of undermining something or someone (i.e., working secretly or underhandedly or 'behind one“s back” against their interests; to undermine something or someone"
         ]
     },
     {
@@ -1399,7 +1399,7 @@
                 "OBJ": "(to be) a party who is subject to governance"
             },
             "(to be) a state/act/event that is political (i.e., motivated by, or in furtherance or support of a particular government or the authorities within that government)",
-            "(to be) the particular collective group of authorities authorized as being the government for a particular community, i.e., \"the [(contextually) current] government\""
+            "(to be) the particular collective group of authorities authorized as being the government for a particular community, i.e., “the [(contextually) current] government”"
         ]
     },
     {
@@ -1496,8 +1496,8 @@
                 "CSV": "(to be) a physical/tangible act of conducting a criminal trial; a piece/aspect/stage/step of the adjudicatory process",
                 "OBJ": "(to be) the defendant in a criminal complaint"
             },
-            "(to be) a presentation of evidence at a trial in support of an alleged crime; an act of prosecution; to prosecute [CTE Specification = \"a criminal allegation\"; OBJ Specification = \"a prosecutor\"]",
-            "(to be) an act of weighing of evidence by a judge or jury; to weigh evidence [CTE Specification = \"a piece of evidence\"; OBJ Specification = \"judge/juror\"] CPT Version = \"verdict\""
+            "(to be) a presentation of evidence at a trial in support of an alleged crime; an act of prosecution; to prosecute [CTE Specification = “a criminal allegation”; OBJ Specification = “a prosecutor”]",
+            "(to be) an act of weighing of evidence by a judge or jury; to weigh evidence [CTE Specification = “a piece of evidence”; OBJ Specification = “judge/juror”] CPT Version = “verdict”"
         ]
     },
     {
@@ -1527,7 +1527,7 @@
             "(to be) a state of legal/business/governmental corruption (e.g., accepting bribes or kickbacks, embezzling funds, back-room or under-the-table deals, quid pro quo arrangements, extortion schemes, etc.)",
             "(to be) a state of material corruption (e.g., of data, records, process flow, etc.)"
         ],
-        "notes": "This root is also used as the **CORRUPTIVE (CRP) Bias Affix**: *\"How corrupt!\" \"What corruption!\"*"
+        "notes": "This root is also used as the **CORRUPTIVE (CRP) Bias Affix**: *“How corrupt!” “What corruption!”*"
     },
     {
         "root": "XČ",

--- a/lexicon/4.3.json
+++ b/lexicon/4.3.json
@@ -12,7 +12,7 @@
             "(to be) a state/act of conscious awareness of and thinking about/considering the present moment one is living through and experiencing/perceiving",
             "(to be) a state/act of acting/doing something to affect/effect/deal with/manipulate one's experience and perception of a given moment in one's life; to act/do something to deal with/affect/effect/manipulate what is happening at a given moment in one's life"
         ],
-        "notes": "This root is also used as **MNF Manifestive Bias**, meaning *\"Ah!\", \"Well, now!\" \"So!\" \"Alright!\"* [Italian *\"Allora!\"*]"
+        "notes": "This root is also used as **MNF Manifestive Bias**, meaning *“Ah!”, “Well, now!” “So!” “Alright!”* [Italian *“Allora!”*]"
     },
     {
         "root": "GV",
@@ -21,7 +21,7 @@
             {
                 "BSC": "(to be/manifest) an affective (i.e., unwilled) state of want/desire [affective state + object of desire]; to want something, to desire something",
                 "CTE": "(to be) the internal, psychological, proprioceptive manifestation of being in a state of desire; to experience such a state",
-                "CSV": "(to be) the outwardly discernible manifestations of a state of desire; to have the \"look\" of (i.e., outwardly manifest the signs of) being in a state of desire",
+                "CSV": "(to be) the outwardly discernible manifestations of a state of desire; to have the “look” of (i.e., outwardly manifest the signs of) being in a state of desire",
                 "OBJ": "(to be) an entity wanted/desired, a want, a desire; to be the entity wanted/desired"
             },
             "(to be/manifest) a wish/hope for something",
@@ -36,7 +36,7 @@
             {
                 "BSC": "(to be) a request + entity requested; to ask for something (out of desire), to request something",
                 "CTE": "(to be) the internal, psychological, proprioceptive manifestation of being in a state of desire; to experience such a state",
-                "CSV": "(to be) the outwardly discernible manifestations of a state of desire; to have the \"look\" of (i.e., outwardly manifest the signs of) being in a state of desire",
+                "CSV": "(to be) the outwardly discernible manifestations of a state of desire; to have the “look” of (i.e., outwardly manifest the signs of) being in a state of desire",
                 "OBJ": "(to be) an entity requested; that which is requested"
             },
             "(to be) a demand + entity demanded; to demand something",
@@ -189,7 +189,7 @@
                 "CSV": "(to be) an act of welcoming someone; the actual words/actions employed to welcome someone; to say words of welcome, to demonstrate one's welcome",
                 "OBJ": "(to be) the party/entity who is welcomed"
             },
-            "(to be) a state/act of hospitality toward a party; to host a guest Specification = \"guest\"]",
+            "(to be) a state/act of hospitality toward a party; to host a guest Specification = “guest”]",
             "(to be) a state/act of temporary commercial/paid accommodation (e.g., at a hotel, inn, resort, retreat, etc.); to accommodate, take in, or host a paying guest (as customer) [OBJ Specification = paying guest]"
         ]
     },
@@ -302,7 +302,7 @@
             "(to be) a state/act of overstating or resorting to hyperbole; to overstate, resort to hyperbole (i.e., exaggeration with the intention to misrepresent)",
             "(to be) a state of being overwrought, over-reaction; to over-react, be overwrought (i.e., an over-the-top emotional or reactionary response the degree of which is not warranted by circumstances)"
         ],
-        "notes": "Derivation: Use the stems of this root with the SIM/1 or TVP/1 affix to generate the concepts of \"underplay\", \"understatement\", \"subtlety\"."
+        "notes": "Derivation: Use the stems of this root with the SIM/1 or TVP/1 affix to generate the concepts of “underplay”, “understatement”, “subtlety”."
     },
     {
         "root": "RŢ",
@@ -343,7 +343,7 @@
                 "CSV": "(to be) a particular act/behavior considered silly/buffoonish",
                 "OBJ": "(to be) a buffoon, a person whose silliness is looked at derisively by others"
             },
-            "(to be) an act/state/instance of absurdist, \"dada-esque\" behavior; to behave in an absurdist, \"dada-esque\" manner [i.e., with the (intended) effect of creating ironic humor through a process of bewilderment/confusion/weirdness/inappropriate irony, etc.]",
+            "(to be) an act/state/instance of absurdist, “dada-esque” behavior; to behave in an absurdist, “dada-esque” manner [i.e., with the (intended) effect of creating ironic humor through a process of bewilderment/confusion/weirdness/inappropriate irony, etc.]",
             "(to be) an act/state/instance of eccentric/surreal behavior; to behave in an eccentric/surreal manner [i.e., with the (intended) effect of creating a sense of the impossible/quasi-contradictory/unimaginable made real/imaginable]"
         ]
     },
@@ -433,10 +433,10 @@
     },
     {
         "root": "TB",
-        "refers": "AUDACITY / \"NERVE\" / CONFRONTATION / CIVIL DISOBEDIENCE",
+        "refers": "AUDACITY / “NERVE” / CONFRONTATION / CIVIL DISOBEDIENCE",
         "stems": [
             {
-                "BSC": "(to be) a state/act of audacity; be audacious (i.e., have the \"nerve\" or pluck or \"balls\" to do something]",
+                "BSC": "(to be) a state/act of audacity; be audacious (i.e., have the “nerve” or pluck or “balls” to do something]",
                 "CTE": "(to be) a psychological state of being/feeling audacious",
                 "CSV": "(to be) a physical act of audacious behavior; to do something audacious",
                 "OBJ": "(to be) what one is audacious about or towards"
@@ -455,8 +455,8 @@
                 "CSV": "(to be) a physical act/manifestation of naïveté or foolishness; to do/say something that is naïve or foolish",
                 "OBJ": "(to be) the situation or circumstances one is (being) foolish/naïve about"
             },
-            "(to be) a state of being obtuse or \"clueless\"; be obtuse or clueless (i.e., fail to draw appropriate/expected conclusions from a situation or fail to recognize a situation for what it is despite the seeming obviousness thereof)",
-            "(to be) a state of ignorance, \"blindness\" or unawareness; be unaware or ignorant of something"
+            "(to be) a state of being obtuse or “clueless”; be obtuse or clueless (i.e., fail to draw appropriate/expected conclusions from a situation or fail to recognize a situation for what it is despite the seeming obviousness thereof)",
+            "(to be) a state of ignorance, “blindness” or unawareness; be unaware or ignorant of something"
         ]
     },
     {
@@ -472,7 +472,7 @@
             "(to be) an act/state of probity, moral uprightness, honesty in one's dealings with others; to behave/act in an honest, morally upright, probative manner",
             "(to be) a state/act of moral sublimity, nobility, virtue; to behave/act/be morally sublime, noble, virtuous"
         ],
-        "notes": "\"disinterest\" does not mean \"lack of interest\", \"boredom\", or \"indifference\""
+        "notes": "“disinterest” does not mean “lack of interest”, “boredom”, or “indifference”"
     },
     {
         "root": "SŢ",
@@ -557,7 +557,7 @@
             "(be) something exigent or critical, of critical importance requiring immediate attention/action",
             "(be) something constituting an emergency; a situation of dire need for immediate action/aid/resolution"
         ],
-        "notes": "This root is also used as the **EXIGENT (EXG) Bias**: — *\"It's now or never!\"*"
+        "notes": "This root is also used as the **EXIGENT (EXG) Bias**: — *“It's now or never!”*"
     },
     {
         "root": "MSK",
@@ -572,7 +572,7 @@
             "(be) a demand; to make a demand",
             "(be) an order or command; to order, to (issue a) command"
         ],
-        "notes": "This root is also used as the **MANDATORY (MAN) Bias**: — *\"take it or leave it,\"* *\"this is your last chance,\"*"
+        "notes": "This root is also used as the **MANDATORY (MAN) Bias**: — *“take it or leave it,”* *“this is your last chance,”*"
     },
     {
         "root": "RMSK",
@@ -592,7 +592,7 @@
                 "BSC": "one's psyche (i.e., the amalgamation of both the conscious and unconscious mind)",
                 "CTE": "(to be) the state of having a psyche; to have a psyche",
                 "CSV": "(to be) a state/act of one's psyche in operation; to experience or engage in conscious or unconscious mental activity",
-                "OBJ": "(to be) a phaneron or quale (i.e., the \"content\" of what is being experienced by one's mind at any given moment)"
+                "OBJ": "(to be) a phaneron or quale (i.e., the “content” of what is being experienced by one's mind at any given moment)"
             },
             "(to be) one's conscious mind (i.e., the amalgamation of consciousness, perception, thinking, judgement, imagination, language, and memory)",
             "one's unconscious mind (i.e., the seat of subliminal perceptions, automatic skills, repressed feelings and values, instinct, etc.)"
@@ -633,7 +633,7 @@
             {
                 "BSC": "(to be) a state/act of spirituality; be spiritual [i.e., a sense/feeling of communion/connectedness to the incorporeal nature/energy of the universe, to the sacred, or what one interprets as God]",
                 "CTE": "(to be) a state of belief/faith in the spiritual realm",
-                "CSV": "(to be) an act/state of being engaged in a spiritual experience; to \"feel the spirit\"",
+                "CSV": "(to be) an act/state of being engaged in a spiritual experience; to “feel the spirit”",
                 "OBJ": "(to be) what one learns/obtains from a spiritual experience"
             },
             "(to be) a state/act of personal transcendence; to transcend to a more spiritual/universal plane of existence",
@@ -645,7 +645,7 @@
         "refers": "MENTAL IMAGE / IMAGINATION / CREATIVITY",
         "stems": [
             {
-                "BSC": "(to be) a mental image of something that is or might be; to form an image in one's mind of something that is or might be [NOTE: while use of the word \"image\" here suggests only a visual mental construct, this stem also refers to tactile, olfactory, gustatory, aural, interoceptive, or other sensory mental constructs]",
+                "BSC": "(to be) a mental image of something that is or might be; to form an image in one's mind of something that is or might be [NOTE: while use of the word “image” here suggests only a visual mental construct, this stem also refers to tactile, olfactory, gustatory, aural, interoceptive, or other sensory mental constructs]",
                 "CTE": "(to be) the state of being (only) a mental image/visualization",
                 "CSV": "(to be) an act/process of forming/holding a mental image; to visualize",
                 "OBJ": "(to be) the mental image itself that one holds/forms in one's mind, a visualization"
@@ -667,7 +667,7 @@
             "(to be) a state/act of being a ghost or spirit from the afterlife or beyond death (e.g., ghost, spirit, zombie, etc.)",
             "(to be) a state/act of being an entity associated with supernatural,magical, spiritual, or a heavenly/infernal realm (e.g., angel, demon, devil, leprechaun, banshee, etc.)"
         ],
-        "notes": "For \"god/deity\", see Stem 3 of the root(-BS-) \"RELIGIOUS BELIEF / RELIGION / RELIGIOUS WORSHIP\""
+        "notes": "For “god/deity”, see Stem 3 of the root(-BS-) “RELIGIOUS BELIEF / RELIGION / RELIGIOUS WORSHIP”"
     },
     {
         "root": "KŠK",
@@ -744,7 +744,7 @@
         "stems": [
             "telepathy",
             "energy medicine [i.e., ability to heal with one's mind]",
-            "psychic surgery [i.e., ability to remove disease or disorder within a body via an \"energetic\" incision that heals immediately afterwards]"
+            "psychic surgery [i.e., ability to remove disease or disorder within a body via an “energetic” incision that heals immediately afterwards]"
         ],
         "see": "SMR"
     },
@@ -769,7 +769,7 @@
     {
         "root": "ŇSML",
         "stems": [
-            "divination (\"reading\" signs/portents in objects, aeromancy, haruspex, etc.)",
+            "divination (“reading” signs/portents in objects, aeromancy, haruspex, etc.)",
             "fortune-telling",
             "aeromancy"
         ],
@@ -788,7 +788,7 @@
             "(to be) something epistemologically real; to exist epistemologically, be epistemologically real (i.e., to exist based on another entity's beliefs, opinions, philosophy, interpretation, societal convention, decree, etc.",
             "(to be) one's own solipsistic existence; to exist solipsistically (i.e., the existence of one's own psyche as the only ontologically existent entity)"
         ],
-        "notes": "The CSV specification of this stem is essentially synonymous with the CTE Specification of Stem 1 of the root(-ŠŘ-) \"SPACETIME / SPACE / PASSAGE OF TIME\""
+        "notes": "The CSV specification of this stem is essentially synonymous with the CTE Specification of Stem 1 of the root(-ŠŘ-) “SPACETIME / SPACE / PASSAGE OF TIME”"
     },
     {
         "root": "LÇ",
@@ -853,7 +853,7 @@
                 "CSV": "(to be) the psychological/linguistic or other means employed by which someone is fooled; to take actions or employ means to fool a party",
                 "OBJ": "(to be) the entity/party fooled"
             },
-            "(to be) an instance/act of \"playing games\" with someone, i.e., to psychologically manipulate another via words/behavior/actions as a means of temporarily making them feel inferior, sad, confused, etc.; to play games with, to toy with",
+            "(to be) an instance/act of “playing games” with someone, i.e., to psychologically manipulate another via words/behavior/actions as a means of temporarily making them feel inferior, sad, confused, etc.; to play games with, to toy with",
             "(to be) an act/state of hypnosis; to hypnotize"
         ]
     },
@@ -902,16 +902,16 @@
     },
     {
         "root": "ČP",
-        "refers": "STUPIDITY / \"SHALLOWNESS\"",
+        "refers": "STUPIDITY / “SHALLOWNESS”",
         "stems": [
             {
-                "BSC": "(to be) a state of being stupid/\"dumb\"/simple-minded; to be stupid/dumb, act stupidly/simple-mindedly",
+                "BSC": "(to be) a state of being stupid/“dumb”/simple-minded; to be stupid/dumb, act stupidly/simple-mindedly",
                 "CTE": "(to be) a state of stupidity/simple-mindedness",
                 "CSV": "(to be) an act of stupidity; do something stupid",
                 "OBJ": "(to be) what one is (being) stupid about"
             },
             "(to be) a state/act of being non-intellectual, non-conceptual/non-analytical in one's thinking; to be non-intellectual/non-analytical in one's thinking",
-            "(to be) a state of being \"shallow\"/anti-intellectual; be \"shallow\"/anti-intellectual, act in a \"shallow\"/anti-intellectual manner (i.e., unconcerned with or indifferent to intellectual prowess or analytical thinking)"
+            "(to be) a state of being “shallow”/anti-intellectual; be “shallow”/anti-intellectual, act in a “shallow”/anti-intellectual manner (i.e., unconcerned with or indifferent to intellectual prowess or analytical thinking)"
         ]
     },
     {
@@ -1069,15 +1069,15 @@
         "refers": "SELF-INTEREST / INDIVIDUALITY / INTEGRITY",
         "stems": [
             {
-                "BSC": "(to be) a state of being egoistic [NOT \"egotistical\"]; concerned with one's self-interest (but not at the expense of other's rights); to be egoistic [NOT \"egotistical\"]",
+                "BSC": "(to be) a state of being egoistic [NOT “egotistical”]; concerned with one's self-interest (but not at the expense of other's rights); to be egoistic [NOT “egotistical”]",
                 "CTE": "(to be) a psychological state of awareness of one's own self-interest",
-                "CSV": "(to be) an act of egoism/self-interest [NOT \"egotism\"]",
+                "CSV": "(to be) an act of egoism/self-interest [NOT “egotism”]",
                 "OBJ": "(to be) one's (sense of) self-interest"
             },
             "(to be) a state of being individualistic; pursuing of one's own rationally-conceived goals to one's own benefit and implicitly to the benefit of others (or at least without harming them)",
             "(to be) a state of having personal integrity, i.e., adherence to one's own values in the face of real-life circumstances"
         ],
-        "notes": "This root reflects self-interest as a virtue, in that it implies egoism not at the expense of others nor interference with others' rights. This root should be distinguished from the root(-ZČ-) \"selfishness/self-centeredness\" which implies negative traits which potentially affect others adversely."
+        "notes": "This root reflects self-interest as a virtue, in that it implies egoism not at the expense of others nor interference with others' rights. This root should be distinguished from the root(-ZČ-) “selfishness/self-centeredness” which implies negative traits which potentially affect others adversely."
     },
     {
         "root": "ẒM",
@@ -1109,7 +1109,7 @@
     },
     {
         "root": "PŠX",
-        "refers": "CONDESCENSION / PATRONIZING BEHAVIOR / \"BABY-ING\"",
+        "refers": "CONDESCENSION / PATRONIZING BEHAVIOR / “BABY-ING”",
         "stems": [
             {
                 "BSC": "(to be) a state/act of condescending behavior toward another; be condescending toward another, display condescension [i.e., behavior toward another as if they are stupid/ignorant/incompetent]",
@@ -1118,7 +1118,7 @@
                 "OBJ": "(to be) the party toward whom one is condescending"
             },
             "(to be) a state/act of patronizing behavior toward another; be patronizing toward another [i.e., behavior toward another as if they are child-like, immature, incapable of understanding/learning]",
-            "(to be) a state/act of \"babying\" or \"fussing\" or \"coddling\" over another as if they are helpless; to \"baby\" another, \"fuss\" over another as if they are helpless"
+            "(to be) a state/act of “babying” or “fussing” or “coddling” over another as if they are helpless; to “baby” another, “fuss” over another as if they are helpless"
         ]
     },
     {
@@ -1155,7 +1155,7 @@
         "stems": [
             "(to be) a degree of emotional/intellectual fulfillment vs. emotional emptiness/hollowness",
             "(to be) a degree of emotional/intellectual stability vs. instability",
-            "(to be) a degree of emotional openness or \"being in touch\" with one's emotions vs. degree of emotional repression"
+            "(to be) a degree of emotional openness or “being in touch” with one's emotions vs. degree of emotional repression"
         ],
         "see": "ŘY"
     },
@@ -1229,7 +1229,7 @@
                 "CSV": "(to be) an act based upon or driven by a principle; to act based on a principle",
                 "OBJ": "(to be) a party/entity that embodies/represents a (moral or ontological) principle/grounds/basis"
             },
-            "(to be) an aspiration / \"dream\" ; to aspire, to \"dream\"",
+            "(to be) an aspiration / “dream” ; to aspire, to “dream”",
             "(to be) one's (free) will; to follow one's will"
         ]
     },
@@ -1243,7 +1243,7 @@
                 "CSV": "(to be) a degree of directness/plain-spokenness/bluntness/candor/frankness",
                 "OBJ": "(to be) an entity/party impacted/affected by one's degree of directness/plain-spokenness/bluntness/candor/frankness"
             },
-            "(to be/manifest a) degree of obviousness / blatancy / be \"glaring\"  (= inability to avoid noticing)",
+            "(to be/manifest a) degree of obviousness / blatancy / be “glaring”  (= inability to avoid noticing)",
             "(to be/manifest a) degree of straight-forwardness, simplicity, matter-of-factness (= absence of guile / trickery / chicanery)"
         ],
         "notes": "Associated Affix: **DRC**"
@@ -1287,7 +1287,7 @@
                 "OBJ": "(to be) what one is insightful about"
             },
             "(to be) a state/act/instance of being astute about something; be astute about something, (i.e., able to see/understand something clearly about something that is obscure/hidden/unobserved to/by others)",
-            "(to be) a state/act/instance of \"seeing through\" something or someone; to \"see through\" something or someone, for something/someone to be transparent to one (i.e., to perceive/understand the true nature/purpose behind a façade/guise/ruse)"
+            "(to be) a state/act/instance of “seeing through” something or someone; to “see through” something or someone, for something/someone to be transparent to one (i.e., to perceive/understand the true nature/purpose behind a façade/guise/ruse)"
         ]
     },
     {
@@ -1306,16 +1306,16 @@
     },
     {
         "root": "KJ",
-        "refers": "\"TOUGHNESS\" / RESILIENCY",
+        "refers": "“TOUGHNESS” / RESILIENCY",
         "stems": [
             {
-                "BSC": "(to be) a state of \"toughness\" or perseverance; to be \"tough\" or perseverant (i.e., having the ability to withstand an adverse situation without significant harm to oneself)",
+                "BSC": "(to be) a state of “toughness” or perseverance; to be “tough” or perseverant (i.e., having the ability to withstand an adverse situation without significant harm to oneself)",
                 "CTE": "(to be) the psychological state of being tough",
                 "CSV": "(to be) the physical manifestation of one's toughness",
                 "OBJ": "(to be) that which one is tough against"
             },
             "(to be) a state of personal resiliency; to be personally resilient (i.e., able to quickly recover from an adverse situation)",
-            "(to be) a state of \"anti-fragility\"; to be \"anti-fragile\" (i.e., not only able to recover from and deal with an adverse situation, but to learn from it so as to be able to handle or deal with such situations in the future more easily)"
+            "(to be) a state of “anti-fragility”; to be “anti-fragile” (i.e., not only able to recover from and deal with an adverse situation, but to learn from it so as to be able to handle or deal with such situations in the future more easily)"
         ]
     },
     {
@@ -1323,13 +1323,13 @@
         "refers": "NOSINESS",
         "stems": [
             {
-                "BSC": "(to be) a state/act of nosiness; be nosy, 'poke one\"s nose\" into another's business [to allow curiosity to cause one to attempt to find or learn something that is not one's business]",
+                "BSC": "(to be) a state/act of nosiness; be nosy, 'poke one“s nose” into another's business [to allow curiosity to cause one to attempt to find or learn something that is not one's business]",
                 "CTE": "(to be) a state of nosiness as a character trait",
                 "CSV": "(to be) a physical act of being nosy (i.e., what actions and/or words one employs that constitute an act of nosiness)",
                 "OBJ": "(to be) that which one discovers or attempts to discover while being nosy"
             },
             "(to be) an act of prying; to pry (i.e., to persistently attempt to discover another's secrets or learn about another's private affairs)",
-            "(to be) an act of interfering or \"butting in\" where/when one is not wanted or where/when inappropriate"
+            "(to be) an act of interfering or “butting in” where/when one is not wanted or where/when inappropriate"
         ]
     },
     {
@@ -1384,8 +1384,8 @@
                 "CSV": "(to be) an instance of (attempting to) understand(ing) another party's perspective or point of view [use CPT version to indicate success]",
                 "OBJ": "(to be) the perspective or point of view of another party; how another party views/understands a situation"
             },
-            "(to be) an instance of recognizing an opportunity for a potential \"win-win\" situation due to being able to see/understand another party's perspective or point of view",
-            "(to be) an instance of recognizing the value of, or necessity for, compromise [i.e., recognize the potential for a \"lose-lose\" situation otherwise]; to recognize the value/necessity of compromise"
+            "(to be) an instance of recognizing an opportunity for a potential “win-win” situation due to being able to see/understand another party's perspective or point of view",
+            "(to be) an instance of recognizing the value of, or necessity for, compromise [i.e., recognize the potential for a “lose-lose” situation otherwise]; to recognize the value/necessity of compromise"
         ]
     },
     {
@@ -1393,7 +1393,7 @@
         "refers": "SETTLING FOR / COMPROMISE / CONCESSION / RESIGNATION",
         "stems": [
             {
-                "BSC": "(to be) an act/state/instance of settling for/on something as \"middle-ground\" or \"good enough\" solution or compromise; to (assent to a) compromise, to reconcile opposing views/constraints/issues by giving up some of one's demands",
+                "BSC": "(to be) an act/state/instance of settling for/on something as “middle-ground” or “good enough” solution or compromise; to (assent to a) compromise, to reconcile opposing views/constraints/issues by giving up some of one's demands",
                 "CTE": "(to be) a compromise or solution/situation one settles for; to do what constitutes a compromise",
                 "CSV": "(to be) an act of settling for/compromising; to do something which constitutes settling for or compromising",
                 "OBJ": "(to be) the situation/entity one compromises about"
@@ -1401,7 +1401,7 @@
             "(to be) an act/state/instance of conceding one's position/viewpoint/stance regarding a situation, allowing an opponent's or antagonist's position to prevail as a means of compromise or to avoid further hostilities/stress",
             "(to be) an act/state/instance of giving up, resigning, walking away from a situation because one recognizes one's position is hopeless or unwinnable"
         ],
-        "notes": "This root is also used as the **ARBITRARY (ARB) Bias Affix**: *\"...Yeah, whatever...\", \"...Ah, what the hell, I'm going ahead and...\"*"
+        "notes": "This root is also used as the **ARBITRARY (ARB) Bias Affix**: *“...Yeah, whatever...”, “...Ah, what the hell, I'm going ahead and...”*"
     },
     {
         "root": "JT",
@@ -1441,10 +1441,10 @@
                 "CSV": "(be) the physical/tangible acts/events constituting a situation involving the type of irony described by the BSC Specification",
                 "OBJ": "(be) the party/entity/situation/circumstance at the focal point of an anticipated but ultimately unrealized outcome, whose non-occurrence does not have the adverse impact/consequences one would have expected."
             },
-            "(be) a seemingly adverse/undesirable/harmful situation/event whose outcome/aftermath ironically leaves the participant in a better/improved/beneficial state that is ultimately interpreted as \"having been worth\" the pain/suffering/turmoil/distress undergone.",
+            "(be) a seemingly adverse/undesirable/harmful situation/event whose outcome/aftermath ironically leaves the participant in a better/improved/beneficial state that is ultimately interpreted as “having been worth” the pain/suffering/turmoil/distress undergone.",
             "(be) a situation/event constituting a case of dramatic irony (i.e., where an audience or uninvolved third party has knowledge/awareness of information of importance to another party who is ignorant of that information)."
         ],
-        "notes": "This root is also used as the **FORTUITOUS (FOR) Bias Affix**: *\"It's just as well that...\"* or \"All's well that ends well...\""
+        "notes": "This root is also used as the **FORTUITOUS (FOR) Bias Affix**: *“It's just as well that...”* or “All's well that ends well...”"
     },
     {
         "root": "ŠŠČ",
@@ -1459,7 +1459,7 @@
             "(be) a coincidence temporally-speaking (i.e., occurring at the same approximate time)",
             "(be) a coincidence, spatially-speaking (i.e., occurring in the same approximate place)"
         ],
-        "notes": "Derivatives: serendipity, good timing, bad timing, bad luck, fortuitousness, be fortuitous\n\nThis root is also used as the **COINCIDENTAL (COI) Bias Affix**: *\"What a coincidence!\""
+        "notes": "Derivatives: serendipity, good timing, bad timing, bad luck, fortuitousness, be fortuitous\n\nThis root is also used as the **COINCIDENTAL (COI) Bias Affix**: *“What a coincidence!”"
     },
     {
         "root": "LF",
@@ -1472,9 +1472,9 @@
                 "OBJ": "(to be) something with a degree of luck/fortune"
             },
             "(to be/manifest a) degree of fate/chance ( = unpredictable circumstances/outcome/event based on unpredictable or random input/circumstances)",
-            "(to be/manifest a) degree of probability; the \"odds\"  ( = quasi-predictable circumstances/outcome based on statistical probability)"
+            "(to be/manifest a) degree of probability; the “odds”  ( = quasi-predictable circumstances/outcome based on statistical probability)"
         ],
-        "notes": "Associated Affix: **LCK**\n\nThis root is also used as the **ACCIDENTAL (ACC) Bias Affix**: *\"As luck would have it...\", \"Fate has decided that...\", \"What luck!\"*"
+        "notes": "Associated Affix: **LCK**\n\nThis root is also used as the **ACCIDENTAL (ACC) Bias Affix**: *“As luck would have it...”, “Fate has decided that...”, “What luck!”*"
     },
     {
         "root": "MLL",
@@ -1485,18 +1485,18 @@
             "feel(ing of) negative wonder (i.e., a sense of dread-based wonder and awe at the power/formidableness of something awful/sad/horrible/devastating/terrible, etc.)"
         ],
         "see": "ÇM",
-        "notes": "This root is also used as the **PROPITIOUS (PPT) Bias Affix**: *\"it's a wonder that\"* as in *\"It's a wonder he didn't break a bone in that fall.\"*"
+        "notes": "This root is also used as the **PROPITIOUS (PPT) Bias Affix**: *“it's a wonder that”* as in *“It's a wonder he didn't break a bone in that fall.”*"
     },
     {
         "root": "LLH",
         "refers": "UNEXPECTED/EXASPERATED BEWILDERMENT",
         "stems": [
-            "feel(ing of) exasperated bewilderment, an \"Huh?\" feeling consisting of exasperation due to a situation/event/outcome turning out to be utterly different than expected/anticipated and utterly bewildering.",
-            "feel(ing of) angry surprise, a \"What the hell?!\" feeling due to a situation/event/outcome turning out to be utterly different than expected/anticipated and utterly enraging, disgusting or offensive",
+            "feel(ing of) exasperated bewilderment, an “Huh?” feeling consisting of exasperation due to a situation/event/outcome turning out to be utterly different than expected/anticipated and utterly bewildering.",
+            "feel(ing of) angry surprise, a “What the hell?!” feeling due to a situation/event/outcome turning out to be utterly different than expected/anticipated and utterly enraging, disgusting or offensive",
             "feel(ing of) feeling of emotional shock and not knowing what to do/say, due to a situation/event/outcome turning out to be utterly different than expected/anticipated and utterly outrageous/shocking."
         ],
         "see": "ÇM",
-        "notes": "This root is also used as the **PERPLEXIVE (PPX) Bias Affix**: — sudden angry bewilderment, as in *\"Huh? What do you mean...?\", \"What the hell?\", \"You gotta be kidding me!\""
+        "notes": "This root is also used as the **PERPLEXIVE (PPX) Bias Affix**: — sudden angry bewilderment, as in *“Huh? What do you mean...?”, “What the hell?”, “You gotta be kidding me!”"
     },
     {
         "root": "NNŢ",
@@ -1511,7 +1511,7 @@
             "(be) an instance of presumptuousness; having pre-conceived notion/idea before (or without) considering evidence to the contrary",
             "(be) an instance of narrow-mindedness; imperviousness to differing points of view; unable to consider any viewpoint"
         ],
-        "notes": "This root is also used as the **PRESUMPTIVE (PSM) Bias Affix**: *\"It can only mean one thing...\", \"and that's that!\", \"and that's all there is to it!\" or \"There's no two ways about it...\"*"
+        "notes": "This root is also used as the **PRESUMPTIVE (PSM) Bias Affix**: *“It can only mean one thing...”, “and that's that!”, “and that's all there is to it!” or “There's no two ways about it...”*"
     },
     {
         "root": "MMŽ",
@@ -1526,14 +1526,14 @@
             "(be) an instance of verbal irony, i.e., a use of words to connote something other than their literal interpretation",
             "(be) an instance of sarcasm; say something sarcastic"
         ],
-        "notes": "Stem 3 can be used with the EMO affix to name various emotions associated with giving/receiving sarcasm.\n\nThis root is also used as the **IRONIC (IRO) Bias Affix**: *\"Oh, nice!\", \"Just great!\", \"Well, now, isn't this lovely!\"*"
+        "notes": "Stem 3 can be used with the EMO affix to name various emotions associated with giving/receiving sarcasm.\n\nThis root is also used as the **IRONIC (IRO) Bias Affix**: *“Oh, nice!”, “Just great!”, “Well, now, isn't this lovely!”*"
     },
     {
         "root": "ŘS",
         "refers": "DEGREE OF ACCEPTANCE/TOLERANCE/CONSENT/PERMISSION/APPROVAL/AGREEMENT",
         "stems": [
             {
-                "BSC": "(to be/manifest a) degree of acceptance/tolerance, \"being okay with something\" [both the state of acceptance and that which is accepted]",
+                "BSC": "(to be/manifest a) degree of acceptance/tolerance, “being okay with something” [both the state of acceptance and that which is accepted]",
                 "CTE": "(to be) a state of acceptability/being accepted",
                 "CSV": "(to be) the physical act/state of accepting or being okay with",
                 "OBJ": "(to be) that which one accepts/tolerates or is okay with"
@@ -1541,7 +1541,7 @@
             "(to be/manifest a) degree of assent/consent ( = granting of informal permission)",
             "(to be/manifest a) degree of agreement/concurrence/accordance with"
         ],
-        "notes": "Associated Affix: **CNS**\n\nThis root is also used as the **APPROBATIVE (APB) Bias Affix**: *'(That's) OK, \"(That's) alright\", \"(That's) good\", \"(That's) fine\", \"Very well\", \"Sure\"*"
+        "notes": "Associated Affix: **CNS**\n\nThis root is also used as the **APPROBATIVE (APB) Bias Affix**: *'(That's) OK, “(That's) alright”, “(That's) good”, “(That's) fine”, “Very well”, “Sure”*"
     },
     {
         "root": "ŘSW",
@@ -1570,7 +1570,7 @@
             "(to be) a state/act of trickery; to trick, to delude",
             "(to be) a state/act of disguising something or oneself; to disguise"
         ],
-        "notes": "For \"impersonation\" see Stem 2 of the root(-MKR-).\n\nThis root lends itself to use with the EMO affix."
+        "notes": "For “impersonation” see Stem 2 of the root(-MKR-).\n\nThis root lends itself to use with the EMO affix."
     },
     {
         "root": "RḐM",
@@ -1584,7 +1584,7 @@
     },
     {
         "root": "ŘF",
-        "refers": "FOOLING / LEGERDEMAIN / \"MAGIC\" TRICK",
+        "refers": "FOOLING / LEGERDEMAIN / “MAGIC” TRICK",
         "stems": [
             {
                 "BSC": "(be) an act of fooling/duping someone [i.e., causing someone to appear/act foolishly or be perceived as naive/gullible for having fallen for a deception]; to fool, to dupe someone",
@@ -1593,7 +1593,7 @@
                 "OBJ": "(be) the party being fooled or duped"
             },
             "(be) an act of legerdemain; perpetrate an act of legerdemain [i.e., an informal or circumstantial trick to give someone the illusion that something has occurred which in fact has not]",
-            "(be) an act of \"magic\"; a magic trick [i.e., a formally created illusion for the purposes of entertainment]"
+            "(be) an act of “magic”; a magic trick [i.e., a formally created illusion for the purposes of entertainment]"
         ]
     },
     {
@@ -1673,7 +1673,7 @@
                 "BSC": "(be) an instance of contemplating one's mortality; realize/contemplate that one is going to die someday and that there is nothing one can do about it",
                 "CTE": "(be) the state of contemplation about one's mortality",
                 "CSV": "(be) a specific thought associated with contemplating one's mortality",
-                "OBJ": "(be) the state of being dead / no longer being alive (as the focus of one's contemplation) [does not mean \"death\" as in the actual act/process of dying, i.e., transitioning from life into death]"
+                "OBJ": "(be) the state of being dead / no longer being alive (as the focus of one's contemplation) [does not mean “death” as in the actual act/process of dying, i.e., transitioning from life into death]"
             },
             "(be) an instance of contemplating whether one's life has any ultimate or lasting meaning or purpose",
             "(be) an instance of contemplating whether there is an afterlife"
@@ -1693,7 +1693,7 @@
             "(be) an instance of being aware that one has committed a social faux pas",
             "(be) an instance of not presuming to speak or act upon one's own opinion/viewpoint due one's awareness of the potential for committing a social faux pas"
         ],
-        "notes": "This root lends itself to use with the EMO affix.\n\nTranslating the OBJECTIVE specification for this stem depends upon the nature of the faux pas, specifically as to whether it signifies the person committing the faux pas or whether the \"impropriety\" is due to a third-party object/person/entity. For example, if the faux pas consists of something inappropriate being said, the OBJ would refer to the person saying the words (since the words themselves would be indicated by the CSV Specification), whereas if the faux pas consists of using the wrong fork or wearing an inappropriate tie, then it would be the fork or the tie marked by OBJ. This should be distinguished from the CSV Specification, which in these examples would not signify the fork or the tie themselves, but rather the incorrect use of the fork or the inappropriateness of wearing the tie."
+        "notes": "This root lends itself to use with the EMO affix.\n\nTranslating the OBJECTIVE specification for this stem depends upon the nature of the faux pas, specifically as to whether it signifies the person committing the faux pas or whether the “impropriety” is due to a third-party object/person/entity. For example, if the faux pas consists of something inappropriate being said, the OBJ would refer to the person saying the words (since the words themselves would be indicated by the CSV Specification), whereas if the faux pas consists of using the wrong fork or wearing an inappropriate tie, then it would be the fork or the tie marked by OBJ. This should be distinguished from the CSV Specification, which in these examples would not signify the fork or the tie themselves, but rather the incorrect use of the fork or the inappropriateness of wearing the tie."
     },
     {
         "root": "ŽŘ",
@@ -1740,7 +1740,7 @@
         "refers": "PREDICAMENT / QUANDARY / CRISIS / DILEMMA",
         "stems": [
             {
-                "BSC": "(be) a state/act of having/facing/being in a predicament/quandary; be in or have/face a predicament/quandary, be in a \"spot/jam/fix/pickle\"  (i.e., being involved in or having to deal with an unexpected negative situation)",
+                "BSC": "(be) a state/act of having/facing/being in a predicament/quandary; be in or have/face a predicament/quandary, be in a “spot/jam/fix/pickle”  (i.e., being involved in or having to deal with an unexpected negative situation)",
                 "CTE": "(be) a state of being unable to know what to do or how to escape a predicament",
                 "CSV": "(be) a state/act of doing something that creates/causes a predicament; to do something to cause/create a predicament",
                 "OBJ": "(be) the predicament itself, i.e., the (set of) circumstance(s)/situation which constitutes an unexpected and undesirable situation"
@@ -1812,7 +1812,7 @@
         "stems": [
             {
                 "BSC": "(to be) the outlook-on-life as described above, including the mental/emotional experience thereof as well as its associated beliefs/thoughts/tenets",
-                "CTE": "(to be) the mental/emotional experience associated with the \"life-stance\" described above",
+                "CTE": "(to be) the mental/emotional experience associated with the “life-stance” described above",
                 "CSV": "(to be) a belief/tenet associated with the outlook-on-life described above",
                 "OBJ": "(to be) a tangible praxis/behavior/activity/act associated with the outlook-on-life as described above"
             },
@@ -1823,7 +1823,7 @@
     },
     {
         "root": "NKR",
-        "refers": "ONES SURROUNDINGS/ENVIRONMENT/SPACE/LOCALE/HOME / \"THE WORLD\"",
+        "refers": "ONES SURROUNDINGS/ENVIRONMENT/SPACE/LOCALE/HOME / “THE WORLD”",
         "stems": [
             {
                 "BSC": "(to be) one's surroundings/environment/space/locale/home (i.e., one's current quasi-permanent location as it relates to the interaction between oneself and one's environment",
@@ -1832,7 +1832,7 @@
                 "OBJ": "(to be) an object/entity directly associated with one's surroundings/environment/space/ locale/home"
             },
             "(to be) one's personal situation/circumstances as it/they relate to, or are determined by, one's location/locale/surroundings/environment/locale/home",
-            "(to be) \"the World\" (i.e., one's sense of their being an external reality/universe in which one lives and with which one interacts); to have/experience a sense of one's place in the World, one's niche, how/where one \"fits in\" to the grand scheme of things"
+            "(to be) “the World” (i.e., one's sense of their being an external reality/universe in which one lives and with which one interacts); to have/experience a sense of one's place in the World, one's niche, how/where one “fits in” to the grand scheme of things"
         ]
     },
     {
@@ -1912,7 +1912,7 @@
         "stems": [
             {
                 "BSC": "(to be) an act/instance of creating a work of art (in any medium)",
-                "CTE": "(be) what is depicted/illustrated/\"meant\" by a work of art",
+                "CTE": "(be) what is depicted/illustrated/“meant” by a work of art",
                 "CSV": "(be) the physical act of creating a work of art",
                 "OBJ": "(be) the medium utilized to create a work of art"
             },
@@ -1975,7 +1975,7 @@
             "(be) something tedious (based on mindless repetition or drudgery) causing one's mind to wander or be inattentive",
             "(be) something insipid, dull, jejune, or uninteresting, which fails to inspire any positive emotional reaction or interest"
         ],
-        "notes": "This root is also used as the **INSIPID (ISP) Bias Affix**: — *\"Meh...(said due to lack of interest)\", \"How boring/tedious/dull!\"*"
+        "notes": "This root is also used as the **INSIPID (ISP) Bias Affix**: — *“Meh...(said due to lack of interest)”, “How boring/tedious/dull!”*"
     },
     {
         "root": "DÇ",

--- a/lexicon/4.4.json
+++ b/lexicon/4.4.json
@@ -4,13 +4,13 @@
         "refers": "COMPLEMENTARY INTERPERSONAL RELATIONSHIP OR INTERACTION",
         "stems": [
             {
-                "BSC": "(to be) a complementary interpersonal relationship or interaction (i.e., where one party is, does, performs, offers, or initiates some state, act, service, etc. which is directed toward, received, dealt with, undergone, submitted to, acted upon, or reacted to, by a \"secondary\" or \"beta\" party)",
+                "BSC": "(to be) a complementary interpersonal relationship or interaction (i.e., where one party is, does, performs, offers, or initiates some state, act, service, etc. which is directed toward, received, dealt with, undergone, submitted to, acted upon, or reacted to, by a “secondary” or “beta” party)",
                 "CTE": "(to be) a state of a complementary interpersonal relationship or interaction taking place or having taken place",
                 "CSV": "(to be) the physical act of engaging in the specifics of a complementary interpersonal relationship or interaction",
                 "OBJ": "(to be) a party engaged in a complementary interpersonal relationship or interaction"
             },
-            "(to be) the state/act/situation initiated, performed, offered, or undergone by the \"alpha\" or \"primary\" party of a complementary interpersonal relationship or interaction",
-            "(to be) the state/act/situation received, submitted to, dealt with, solicited or undergone by the \"beta\" or \"secondary\" party of a complementary interpersonal relationship or interaction"
+            "(to be) the state/act/situation initiated, performed, offered, or undergone by the “alpha” or “primary” party of a complementary interpersonal relationship or interaction",
+            "(to be) the state/act/situation received, submitted to, dealt with, solicited or undergone by the “beta” or “secondary” party of a complementary interpersonal relationship or interaction"
         ]
     },
     {
@@ -19,7 +19,7 @@
         "stems": [
             {
                 "BSC": "(to be) a state/act of [attempted] predation upon a prey and the prey's attempt to flee or defend itself",
-                "CTE": "(to be) a state of a predation (i.e., the \"nature\" of the predator/prey relationship)",
+                "CTE": "(to be) a state of a predation (i.e., the “nature” of the predator/prey relationship)",
                 "CSV": "(to be) the physical act of predation by a predator and defensive act of its (potential) prey",
                 "OBJ": "(to be) a party to a predator~prey relationship"
             },
@@ -165,7 +165,7 @@
     },
     {
         "root": "ZGW",
-        "refers": "BEING A MATCHMAKER ↔ BEING A PARTY MATCHED OR \"SET UP\" BY A MATCHMAKER",
+        "refers": "BEING A MATCHMAKER ↔ BEING A PARTY MATCHED OR “SET UP” BY A MATCHMAKER",
         "see": "LÇL"
     },
     {

--- a/lexicon/4.5.1.1.json
+++ b/lexicon/4.5.1.1.json
@@ -12,7 +12,7 @@
             "(be) a state/instance of hearing a boom (i.e., a low-pitched bang/explosive sound)",
             "(be) a state/instance of hearing an explosion (e.g., detonation of a bomb, an explosion of an engine or large powerful machine, etc.)"
         ],
-        "notes": "Particular attention should be paid to the use of Phase categories when using this and related roots, as well as various qualitative affixes, e.g., the word for a \"crackling\" sound would be derived from stem referring to a more basic single sound such as \"pop\" or \"snap\", \"rattle\" would be derived from \"click\" or \"clack\", while \"jingling/tinkling\" would be derived from \"clank\" or \"ping/ding/ring\" (or perhaps the concatenation of one with the other)."
+        "notes": "Particular attention should be paid to the use of Phase categories when using this and related roots, as well as various qualitative affixes, e.g., the word for a “crackling” sound would be derived from stem referring to a more basic single sound such as “pop” or “snap”, “rattle” would be derived from “click” or “clack”, while “jingling/tinkling” would be derived from “clank” or “ping/ding/ring” (or perhaps the concatenation of one with the other)."
     },
     {
         "root": "GP",
@@ -48,7 +48,7 @@
         "root": "ZŇ",
         "refers": "SOUND OF A CLINK / CLANK / CLACK",
         "stems": [
-            "sound of a clink (e.g., sound of a wineglass being lightly struck or \"light\" metallic striking sound, etc.)",
+            "sound of a clink (e.g., sound of a wineglass being lightly struck or “light” metallic striking sound, etc.)",
             "sound of a clank(ing) (e.g., something metallic striking a hard surface)",
             "sound of a clack (i.e., a higher-pitched knock between solid objects, e.g., of passing train wheels on a track)"
         ],
@@ -88,12 +88,12 @@
         "root": "ÇW",
         "refers": "SOUND OF A POOF / WHOOSH / SIZZLE",
         "stems": [
-            "sound of a poof (i.e., the soft/slight \"popping\" sound of sudden air (de-)pressurization due to a sudden displacement of air)",
+            "sound of a poof (i.e., the soft/slight “popping” sound of sudden air (de-)pressurization due to a sudden displacement of air)",
             "sound of a woosh (i.e., the sound of drawn-out air displacement due to air (re-)pressurization through a constriction or narrowing of a channel)",
             "sound of sizzling"
         ],
         "see": "BJ",
-        "notes": "EDITOR NOTE: Listed as the root(-ÇT-) in the Lexicon, identical to the entry for \"SOUND OF A HISS / WIND HOWLING / WHISTLE\", replaced with the more onomatopoeic -ÇW- based on a suggestion from Reddit user /u/ChinskiEpierOzki."
+        "notes": "EDITOR NOTE: Listed as the root(-ÇT-) in the Lexicon, identical to the entry for “SOUND OF A HISS / WIND HOWLING / WHISTLE”, replaced with the more onomatopoeic -ÇW- based on a suggestion from Reddit user /u/ChinskiEpierOzki."
     },
     {
         "root": "ŘẒ",
@@ -109,7 +109,7 @@
         "root": "ŽD",
         "refers": "SOUND OF A ZAP / BUZZ / BEEP / PING",
         "stems": [
-            "sound of a zap / buzz (i.e., a low-oscillating sound which becomes the word \"buzz\" under duration, e.g., a bee flying, a door buzzer, a \"wrong answer\" signal on a TV game show, etc.)",
+            "sound of a zap / buzz (i.e., a low-oscillating sound which becomes the word “buzz” under duration, e.g., a bee flying, a door buzzer, a “wrong answer” signal on a TV game show, etc.)",
             "sound of a beep / bleep (i.e., a high-pitched buzz)",
             "sound of a ping / ding"
         ],
@@ -120,7 +120,7 @@
         "refers": "SOUND OF CREAKING / SQUISHING / SQUELCHING / TEARING",
         "stems": [
             "sound of a creak (e.g., walls of old wooden house shifting, old floorboards being walked upon, etc.)",
-            "sound of squishing / squelching (i.e., a sound of something \"liquidy\" or gelatinous being squeezed or crushed)",
+            "sound of squishing / squelching (i.e., a sound of something “liquidy” or gelatinous being squeezed or crushed)",
             "sound of a tearing/ripping (e.g., of paper, cardboard, fabric, etc.)"
         ],
         "see": "BJ"
@@ -192,7 +192,7 @@
         "stems": [
             "sound made by a part of one's body that mimics a non-bodily sound",
             "sound made by a part of one's body that potentially creates a humorous or embarassing effect (e.g., fart, cracking knuckles)",
-            "a non-linguistic oral sound made to/for humorous or shocking effect (e.g., a \"raspberry\", a sound of deliberate slobbering, a whistle, etc.)"
+            "a non-linguistic oral sound made to/for humorous or shocking effect (e.g., a “raspberry”, a sound of deliberate slobbering, a whistle, etc.)"
         ],
         "see": "BJ",
         "notes": "Concatenate a stem from another auditory root with these stems to specify the type or nature of the sound being made."

--- a/lexicon/4.5.1.2.json
+++ b/lexicon/4.5.1.2.json
@@ -24,7 +24,7 @@
                 "OBJ": "(be) the entity or circumstances creating a patterned sound"
             },
             "(be) a state/act/instance of emitting a patterned sound; to emit a sound containing an audible pattern",
-            "(be) a state/instance of a sound being rhythmic; [for a sound] to have a rhythm(ic pulse) or \"beat\""
+            "(be) a state/instance of a sound being rhythmic; [for a sound] to have a rhythm(ic pulse) or “beat”"
         ]
     },
     {

--- a/lexicon/4.5.1.3.1.json
+++ b/lexicon/4.5.1.3.1.json
@@ -668,8 +668,8 @@
         "root": "ÇKM",
         "refers": "AEROPHONE MUSICAL INSTRUMENT",
         "stems": [
-            "\"wind\" instrument which, when played, contains an enclosed column of vibrating air (e.g., clarinet, oboe, flute, didgeridoo, etc.)",
-            "\"free reed\" instrument which utilize a reed or band but do not contain the vibrating air (e.g., harmonica, accordion, harmonium)",
+            "“wind” instrument which, when played, contains an enclosed column of vibrating air (e.g., clarinet, oboe, flute, didgeridoo, etc.)",
+            "“free reed” instrument which utilize a reed or band but do not contain the vibrating air (e.g., harmonica, accordion, harmonium)",
             "instrument where an unenclosed air flow is interrupted other than by a reed or band (e.g., bullroarer, siren, boomwhacker, corrugaphone, whip)"
         ],
         "see": "i.e., vibration of a volume of air"

--- a/lexicon/4.5.10.1.json
+++ b/lexicon/4.5.10.1.json
@@ -3,7 +3,7 @@
         "root": "SMW",
         "stems": [
             "feel(ing of) calm and rationality",
-            "feel(ing of) serenity, feel(ing) mentally/emotionally \"refreshed\"",
+            "feel(ing of) serenity, feel(ing) mentally/emotionally “refreshed”",
             "feel(ing of) emotional well-being/peace of mind"
         ],
         "see": "ÇM"
@@ -13,7 +13,7 @@
         "stems": [
             "feel(ing of) enjoyment",
             "feel(ing of) excitement",
-            "feel(ing of) a thrill, \"whee!\""
+            "feel(ing of) a thrill, “whee!”"
         ],
         "see": "ÇM"
     },
@@ -65,7 +65,7 @@
     {
         "root": "GZZ",
         "stems": [
-            "feel(ing of) elation, feel(ing of being) on an emotional \"high\"",
+            "feel(ing of) elation, feel(ing of being) on an emotional “high”",
             "feel(ing of) euphoria, bliss",
             "feel(ing of) ecstasy"
         ],
@@ -93,7 +93,7 @@
         "root": "RPL",
         "stems": [
             "feel(ing of being) upbeat / in a good mood",
-            "feel(ing of) being spirited, feeling \"alive\", feeling uplifted",
+            "feel(ing of) being spirited, feeling “alive”, feeling uplifted",
             "feel(ing of) mental/spiritual youthfulness and joie-de-vivre"
         ],
         "see": "ÇM"

--- a/lexicon/4.5.10.2.json
+++ b/lexicon/4.5.10.2.json
@@ -31,7 +31,7 @@
         "stems": [
             "feel(ing of being) part of something, feeling of belonging",
             "feel(ing of) familiarity, feel(ing of being able to be) one's true self due to sense of familiarity with surroundings and the people present",
-            "feel(ing of) coziness, \"home-sweet-home\" feeling, hygge"
+            "feel(ing of) coziness, “home-sweet-home” feeling, hygge"
         ],
         "see": "ÇM"
     },
@@ -83,7 +83,7 @@
     {
         "root": "MTL",
         "stems": [
-            "feel(ing of) poignancy (= \"aaw\" reaction to an event characterized by irresistible cuteness)",
+            "feel(ing of) poignancy (= “aaw” reaction to an event characterized by irresistible cuteness)",
             "feel(ing of) poignancy, feeling touched or moved by witnessing an act/event of compassion/tenderness/love, etc.)",
             "feel(ing of having) the capacity to be easily moved"
         ],
@@ -101,9 +101,9 @@
     {
         "root": "LŠ",
         "stems": [
-            "feel(ing of) exaltation, \"being on top of the world\"",
+            "feel(ing of) exaltation, “being on top of the world”",
             "feel(ing of) ecstatic awareness at the joy and wonder of being alive",
-            "feel(ing of) achieving a moment in which one's life-state is perfect; an \"it doesn't get any better than this\" feeling"
+            "feel(ing of) achieving a moment in which one's life-state is perfect; an “it doesn't get any better than this” feeling"
         ],
         "see": "ÇM"
     },
@@ -111,7 +111,7 @@
         "root": "CD",
         "stems": [
             "feeling of love for existence / pantheistic love",
-            "feeling of inherent \"connection\" to or oneness with the universe through space and time",
+            "feeling of inherent “connection” to or oneness with the universe through space and time",
             "feeling of being deeply/personally moved/contemplative/humbled by something extraordinary such as a work of art, a moving speech, an inspiring sight of Nature, etc. Akin to the Spanish-language notion of duende, but applied to contexts beyond art."
         ],
         "see": "ÇM"
@@ -120,7 +120,7 @@
         "root": "LTR",
         "stems": [
             "feel(ing of being) romantic (i.e., preoccupied with idealized, fabulous notions of life, adventure, and love)",
-            "feel(ing of having) a head-in-the-clouds fantasy feeling, \"dreaming\"",
+            "feel(ing of having) a head-in-the-clouds fantasy feeling, “dreaming”",
             "feel(ing of being) lost in one's fantasies and daydreams"
         ],
         "see": "ÇM"
@@ -137,7 +137,7 @@
     {
         "root": "MMĻ",
         "stems": [
-            "feel(ing of) sudden clarity/understanding upon discovery of the solution to a problem/puzzle/mystery — the \"a-ha!\" moment",
+            "feel(ing of) sudden clarity/understanding upon discovery of the solution to a problem/puzzle/mystery — the “a-ha!” moment",
             "feel(ing of) personal triumph, of conquering a personal challenge",
             "feel(ing of) victory, that one has vanquished an enemy"
         ],

--- a/lexicon/4.5.10.3.json
+++ b/lexicon/4.5.10.3.json
@@ -4,7 +4,7 @@
         "stems": [
             "feel(ing of being) judgmental",
             "feel(ing of) contempt; morally superior feeling + disgust, anger, or resentment",
-            "feel(ing of) vindictiveness, feeling of an \"injustice collector\""
+            "feel(ing of) vindictiveness, feeling of an “injustice collector”"
         ],
         "see": "ÇM"
     },
@@ -183,7 +183,7 @@
         "root": "ĻĻČ",
         "stems": [
             "feel(ing of being) startled",
-            "feel(ing of being) dazzled/astounded/spellbound, \"wow!\"",
+            "feel(ing of being) dazzled/astounded/spellbound, “wow!”",
             "feel(ing of being) aghast/dumbfounded, feel stupefaction/stupor"
         ],
         "see": "ÇM"
@@ -201,8 +201,8 @@
         "root": "ČB",
         "stems": [
             "feel(ing of being) daring, feel(ing) like taking a risk",
-            "(have) the nerve to, (have) the \"cheek\" to",
-            "feel(ling of) dauntlessness, \"devil-may-care\" attitude"
+            "(have) the nerve to, (have) the “cheek” to",
+            "feel(ling of) dauntlessness, “devil-may-care” attitude"
         ],
         "see": "ÇM"
     },

--- a/lexicon/4.5.10.4.json
+++ b/lexicon/4.5.10.4.json
@@ -39,7 +39,7 @@
         "root": "KÇÇ",
         "stems": [
             "feel(ing of) frustration, exasperation",
-            "feel(ing) emotionally upset, \"not know what to think\"",
+            "feel(ing) emotionally upset, “not know what to think”",
             "feel(ing of being) disconcerted, defeated"
         ],
         "see": "ÇM"
@@ -75,7 +75,7 @@
         "root": "JDR",
         "stems": [
             "feel(ing of) emotional stress/pressure",
-            "feel(ing of being) at emotional breaking-point, feel(ing) that one \"can't take it anymore\"",
+            "feel(ing of being) at emotional breaking-point, feel(ing) that one “can't take it anymore”",
             "feel(ing of being) on the verge of loss of control of one's composure or inhibitions [CPT = loss of emotional control; nervous breakdown]"
         ],
         "see": "ÇM"
@@ -101,8 +101,8 @@
     {
         "root": "BGR",
         "stems": [
-            "feel(ing of) mental \"fogginess\", inability to concentrate or focus",
-            "feel(ing of) mental lassitude, mental laziness, feel uninspired / \"stuck in a rut\"",
+            "feel(ing of) mental “fogginess”, inability to concentrate or focus",
+            "feel(ing of) mental lassitude, mental laziness, feel uninspired / “stuck in a rut”",
             "feel(ing of) anhedonia [inability to feel/experience pleasure]"
         ],
         "see": "ÇM"
@@ -110,7 +110,7 @@
     {
         "root": "JBR",
         "stems": [
-            "feel(ing of) restlessness/disquietude/tension/being \"on edge\"",
+            "feel(ing of) restlessness/disquietude/tension/being “on edge”",
             "feel(ing of) nervousness / agitation",
             "feel(ing of) hysteria/loss of emotional control"
         ],
@@ -391,7 +391,7 @@
         "stems": [
             "feel(ing of being) like a stranger in one's own life, like one does not understand oneself",
             "feel(ing of) alienation from self and others (resigned disgust with oneself and one's inability to understand the world)",
-            "feel(ing of) disconnection or inability to relate to the world, feeling emotionally \"adrift\" (i.e., a quiet combination of boredom and resignation and bewilderment) in relation to the world"
+            "feel(ing of) disconnection or inability to relate to the world, feeling emotionally “adrift” (i.e., a quiet combination of boredom and resignation and bewilderment) in relation to the world"
         ],
         "see": "ÇM"
     },
@@ -399,7 +399,7 @@
         "root": "RKR",
         "stems": [
             "feel(ing of) aloofness",
-            "feel(ing of) emotional superiority/maturity/feeling \"above it all\"",
+            "feel(ing of) emotional superiority/maturity/feeling “above it all”",
             "feel(ing of) disgust/spite at the inferiority/stupidity of other people"
         ],
         "see": "ÇM"
@@ -445,7 +445,7 @@
         "stems": [
             "feel(ing of) pettiness, feel(ing of) unwarranted concern for trivial matters",
             "feel(ing of) fussiness, finickiness (= spirit of uncooperativeness over trivial matters)",
-            "feel(ing of) a need to meddle/interfere/\"butt in\""
+            "feel(ing of) a need to meddle/interfere/“butt in”"
         ],
         "see": "ÇM"
     },

--- a/lexicon/4.5.10.json
+++ b/lexicon/4.5.10.json
@@ -6,7 +6,7 @@
             {
                 "BSC": "(to be in) a non-volitional (affective) state (both internal, psychological manifestations and external, visible manifestations)",
                 "CTE": "(to be) the internal psychological, and proprioceptive sensation of being in such a state; to experience such manifestations",
-                "CSV": "(to be) the \"look\" of being in such a state. i.e., the outward (visible or externally discernible) manifestation of being an affective state; to have the \"look\" of, (i.e., outwardly manifest the signs of) being in an emotional state",
+                "CSV": "(to be) the “look” of being in such a state. i.e., the outward (visible or externally discernible) manifestation of being an affective state; to have the “look” of, (i.e., outwardly manifest the signs of) being in an emotional state",
                 "OBJ": "(to be) the act/event/situation/circumstance(s) which trigger or give rise to an affective state"
             },
             "[same as Stem 1 except that the affective state is specifically a non-volitional emotional state]",

--- a/lexicon/4.5.2.json
+++ b/lexicon/4.5.2.json
@@ -9,10 +9,10 @@
                 "CSV": "(to be) an act of smelling; to smell; to engage one's olfactory sense",
                 "OBJ": "(to be) the entity/event/object whose odor one smells"
             },
-            "(to be) one's olfactory bulb or \"nose\" [as olfactory organ, not one's nasal proboscis (see -LMW-)]",
+            "(to be) one's olfactory bulb or “nose” [as olfactory organ, not one's nasal proboscis (see -LMW-)]",
             "(to be) one's olfactory faculty; one's sense of smell"
         ],
-        "notes": "MORPHOLOGICAL DERIVATIVES: sniff, aroma, \"bouquet\", perfume, stench\n\nThe OLF affix can be used to identify additional odors associated with any applicable formative."
+        "notes": "MORPHOLOGICAL DERIVATIVES: sniff, aroma, “bouquet”, perfume, stench\n\nThe OLF affix can be used to identify additional odors associated with any applicable formative."
     },
     {
         "root": "NKY",
@@ -22,7 +22,7 @@
                 "BSC": "(to be) something having a pungent odor (e.g., vinegar, ammonia, urine, stale coffee, vomit, etc.)",
                 "CTE": "(to be/manifest) the particular pungent odor (of something)",
                 "CSV": "(to be) the odor perceived by an observer as being identifiable as a particular pungent odor (i.e., the odor of something known)",
-                "OBJ": "(to be) an entity having a pungent odor (e.g., \"the pungent-smelling one\")"
+                "OBJ": "(to be) an entity having a pungent odor (e.g., “the pungent-smelling one”)"
             },
             "funky odor (e.g., of sweat, livestock, musk, tamari, ambergris, stinky cheeses, etc.)",
             "putrid odor (e.g., as of rotting eggs, roadkill, feces, sulfur, low-tide, etc.)"

--- a/lexicon/4.5.3.json
+++ b/lexicon/4.5.3.json
@@ -22,7 +22,7 @@
                 "BSC": "(to be) something having a sweet flavor",
                 "CTE": "(to be/manifest) a particular sweet flavor (of something)",
                 "CSV": "(to be) an identifiable sweet flavor",
-                "OBJ": "(to be) an entity having a sweet flavor (e.g., \"the sweet-tasting one\")"
+                "OBJ": "(to be) an entity having a sweet flavor (e.g., “the sweet-tasting one”)"
             },
             "fruity/citrus/tarty-flavor",
             "floral-like sweet flavor"

--- a/lexicon/4.5.4.json
+++ b/lexicon/4.5.4.json
@@ -22,12 +22,12 @@
                 "BSC": "(to be) something having a (particular) color / something colored",
                 "CTE": "(to be/manifest) the particular color (of something)",
                 "CSV": "(to be/manifest) the (reflected) light of (a certain wavelength) that is perceived by an observer as being a particular color",
-                "OBJ": "(to be) an entity having a particular color (e.g., \"the red one\")"
+                "OBJ": "(to be) an entity having a particular color (e.g., “the red one”)"
             },
             "Same as Stem 1 but a hue 15 degrees counter-clockwise on a 8-basic-valued 360-degree color-wheel (i.e., one-third of the way to the next basic color value, or half-way to Stem 3 of the next basic color value).",
             "Same as Stem 1 but a hue 15 degrees clockwise on a 8-basic-valued 360-degree color-wheel (i.e., one-third of the way to the next basic color value, or half-way to Stem 2 of the next basic color value)."
         ],
-        "notes": "The CLD and COL affixes can be used with all color stems (and as well as non-color stems where semantically productive). For dichromatic (2-colored) descriptions, concatenate one color stem into another using COMITATIVE format.\n\nThe Western basic color terms \"pink\" and \"brown\" do not have roots. The various shades covered by these two color terms are expressed as derivatives of red or magenta, and orange respectively. Use of the CLD affix also provides terms for more obscure shades such as \"peach\", \"mauve\", \"turquoise\", \"indigo\", \"olive\", \"rust\", \"burnt sienna\", \"cobalt blue\", \"forest green\", \"beige\", \"burgundy\", etc.\n\nUsing the COL affix in conjunction with the Phase and Modulative affixes, one can add qualities such as \"gleaming\", \"twinkling\", \"opalescent\", \"glittering\", etc. In addition to the above scheme, the COL/7 affix provides for terms based on the color of a tangible object."
+        "notes": "The CLD and COL affixes can be used with all color stems (and as well as non-color stems where semantically productive). For dichromatic (2-colored) descriptions, concatenate one color stem into another using COMITATIVE format.\n\nThe Western basic color terms “pink” and “brown” do not have roots. The various shades covered by these two color terms are expressed as derivatives of red or magenta, and orange respectively. Use of the CLD affix also provides terms for more obscure shades such as “peach”, “mauve”, “turquoise”, “indigo”, “olive”, “rust”, “burnt sienna”, “cobalt blue”, “forest green”, “beige”, “burgundy”, etc.\n\nUsing the COL affix in conjunction with the Phase and Modulative affixes, one can add qualities such as “gleaming”, “twinkling”, “opalescent”, “glittering”, etc. In addition to the above scheme, the COL/7 affix provides for terms based on the color of a tangible object."
     },
     {
         "root": "GY",

--- a/lexicon/4.5.5.json
+++ b/lexicon/4.5.5.json
@@ -22,7 +22,7 @@
                 "BSC": "(to be) something having a chunky texture or tactile sensation (chunk-like, irregular/coarse pieces one can easily hold between thumb and forefinger)",
                 "CTE": "(to be/have) a chunky texture or tactile sensation",
                 "CSV": "(to be) the chunky texture or tactile sensation perceived and being identifiable as a particular texture or tactile sensation (i.e., the texture or tactile sensation of something known)",
-                "OBJ": "(to be) an object/entity having a chunky texture or tactile sensation (e.g., \"the chunky-feeling one\")"
+                "OBJ": "(to be) an object/entity having a chunky texture or tactile sensation (e.g., “the chunky-feeling one”)"
             },
             "gravel-like sensation",
             "coarse/gritty sensation like sand"
@@ -44,7 +44,7 @@
         "stems": [
             "flaky textured",
             "scaly textured",
-            "\"confetti\" textured - like small flat pieces of paper"
+            "“confetti” textured - like small flat pieces of paper"
         ],
         "see": "GS"
     },
@@ -273,8 +273,8 @@
         "refers": "ORAL TEXTURE",
         "stems": [
             "chewy texture (in mouth)",
-            "\"tough\" texture (in mouth, e.g., of meat)",
-            "\"melt-in-your-mouth\" savory texture"
+            "“tough” texture (in mouth, e.g., of meat)",
+            "“melt-in-your-mouth” savory texture"
         ],
         "see": "GS"
     },
@@ -314,7 +314,7 @@
         "stems": [
             "wispy/wafting/misty texture",
             "fluffy/puffy/cottony texture",
-            "\"cobwebby\"/like cotton-candy texture"
+            "“cobwebby”/like cotton-candy texture"
         ],
         "see": "GS"
     }

--- a/lexicon/4.5.6.json
+++ b/lexicon/4.5.6.json
@@ -25,10 +25,10 @@
     },
     {
         "root": "LŢN",
-        "refers": "PHYSICAL \"HIGH\" / ALTERED STATE OF CONSCIOUSNESS",
+        "refers": "PHYSICAL “HIGH” / ALTERED STATE OF CONSCIOUSNESS",
         "stems": [
-            "natural \"high\" / natural state of euphoria (physical/sensory, not emotional in origin)",
-            "chemically-induced \"high\"",
+            "natural “high” / natural state of euphoria (physical/sensory, not emotional in origin)",
+            "chemically-induced “high”",
             "trance-like state / altered state of consciousness"
         ],
         "see": "ḐH"
@@ -39,7 +39,7 @@
         "stems": [
             "feel good, feel sense of physical well-being",
             "feel relaxed",
-            "feel post-orgasmic/post-coital bliss; \"afterglow\""
+            "feel post-orgasmic/post-coital bliss; “afterglow”"
         ],
         "see": "ḐH"
     },
@@ -79,7 +79,7 @@
         "stems": [
             "sigh",
             "huff (as in indignation, annoyance, or anger)",
-            "puff, blow out [held] breath (as when relieved, caught off guard, saying \"phew!\")"
+            "puff, blow out [held] breath (as when relieved, caught off guard, saying “phew!”)"
         ],
         "see": "ḐH"
     },
@@ -158,8 +158,8 @@
         "refers": "FEEL INTEROCEPTIVE BODILY MOVEMENT",
         "stems": [
             "feel bloated/gassy",
-            "feel stomach/intestines \"rumbling\"",
-            "feel stomach contents \"shift\""
+            "feel stomach/intestines “rumbling”",
+            "feel stomach contents “shift”"
         ],
         "see": "ḐH"
     },
@@ -169,7 +169,7 @@
         "stems": [
             "feel a tickle",
             "feel a prickly sensation",
-            "feel an \"ants/spiders crawling\" sensation"
+            "feel an “ants/spiders crawling” sensation"
         ],
         "see": "ḐH"
     },
@@ -189,7 +189,7 @@
         "stems": [
             "feel vestibular lack of balance; feel off-balance/unbalanced / having impaired balance / off-kilter",
             "feel awkwardness/unfamiliarity with one's bodily motor coordination (e.g., when drunk, following a stroke, during puberty, etc.)",
-            "feel \"shaky\", difficulty in controlling one's vestibular/muscular coordination (e.g., due to emotional shock, illness, fright, etc.)"
+            "feel “shaky”, difficulty in controlling one's vestibular/muscular coordination (e.g., due to emotional shock, illness, fright, etc.)"
         ],
         "see": "ḐH"
     },
@@ -219,7 +219,7 @@
         "stems": [
             "sensation from having body or part of body rubbed or massaged",
             "sensation from having back or other body part scratched (for pleasure or to relieve itch)",
-            "caress / feel of \"soft touch\" / \"social touch\" (a.k.a. affective touch, somatosensory touch)"
+            "caress / feel of “soft touch” / “social touch” (a.k.a. affective touch, somatosensory touch)"
         ],
         "see": "ḐH"
     },
@@ -238,7 +238,7 @@
         "root": "JDW",
         "refers": "AFFECTIVE TACTILE REACTIONS",
         "stems": [
-            "feel \"a thrill down one's spine\"",
+            "feel “a thrill down one's spine”",
             "feel one's 'hairs standing on the back of one's neck'",
             "have the creeps / have the willies"
         ],
@@ -246,11 +246,11 @@
     },
     {
         "root": "JDV",
-        "refers": "NUMBNESS / \"PINS & NEEDLES\" FEELING",
+        "refers": "NUMBNESS / “PINS & NEEDLES” FEELING",
         "stems": [
-            "feel that a limb has \"fallen asleep\"",
-            "\"pins & needles\" feeling in one's limb (after it has been \"asleep\")",
-            "feel internal numbness or \"dead\" feeling (i.e., a lack of an expected internal sensation)"
+            "feel that a limb has “fallen asleep”",
+            "“pins & needles” feeling in one's limb (after it has been “asleep”)",
+            "feel internal numbness or “dead” feeling (i.e., a lack of an expected internal sensation)"
         ],
         "see": "ḐH"
     },
@@ -258,7 +258,7 @@
         "root": "KŘ",
         "refers": "FEEL ILL / SICK / WEAKNESS",
         "stems": [
-            "feel ill/sick/unhealthy; feeling of general malaise, feel \"blah\", feel so-so, feel poorly",
+            "feel ill/sick/unhealthy; feeling of general malaise, feel “blah”, feel so-so, feel poorly",
             "feel torpor/lethargy",
             "feel weakness"
         ],
@@ -298,7 +298,7 @@
         "root": "ẒGŘ",
         "refers": "INTERNAL BURNING/TINGLING/PRICKLY SENSATION",
         "stems": [
-            "have/feel an internal \"burning\" sensation",
+            "have/feel an internal “burning” sensation",
             "have/feel an internal tingling sensation",
             "have/feel an internal prickly/stinging sensation"
         ],
@@ -328,9 +328,9 @@
         "root": "ẒG",
         "refers": "ACHE / SHARP PAIN / RADIATING PAIN",
         "stems": [
-            "feel/have an ache (i.e., diffuse, non-sharp pain) [using SUF/EXN affixes, this stem can mean \"feel throbbing/pounding pain\"]",
+            "feel/have an ache (i.e., diffuse, non-sharp pain) [using SUF/EXN affixes, this stem can mean “feel throbbing/pounding pain”]",
             "feel sharp/stabbing pain",
-            "feel radiating \"shooting\" pain"
+            "feel radiating “shooting” pain"
         ],
         "see": "ḐH"
     },
@@ -340,7 +340,7 @@
         "stems": [
             "have no appetite (even though one has not recently eaten)",
             "feel queasy (mildly nauseous feeling)",
-            "feel nauseous; have nausea, feel as if one is going to vomit [CPT version = \"to vomit\"]"
+            "feel nauseous; have nausea, feel as if one is going to vomit [CPT version = “to vomit”]"
         ],
         "see": "ḐH"
     },
@@ -348,8 +348,8 @@
         "root": "ḐČ",
         "refers": "BLACK-OUT / SPELL / SEIZURE",
         "stems": [
-            "experience a feeling of \"blanking out\" or \"blacking out\"",
-            "experience an episode or spell of inattention or loss of awareness/focus; to \"zone out\" / \"space out\"",
+            "experience a feeling of “blanking out” or “blacking out”",
+            "experience an episode or spell of inattention or loss of awareness/focus; to “zone out” / “space out”",
             "experience a seizure"
         ],
         "see": "ḐH"

--- a/lexicon/4.5.7.json
+++ b/lexicon/4.5.7.json
@@ -38,7 +38,7 @@
         "refers": "MOOD /TEMPERAMENT / NATURE",
         "stems": [
             "mood; behave based on a mood",
-            "one's natural/usual \"default\" demeanor / temperament",
+            "one's natural/usual “default” demeanor / temperament",
             "one's nature / the essence of one's sense of self"
         ],
         "see": "TW"
@@ -123,7 +123,7 @@
             "feel psychological sense of satisfaction/satiety"
         ],
         "see": "TW",
-        "notes": "This root is also used as the **SATIATIVE (SAT) Bias Affix**: *\"How satisfying...!\", \"At least, the pleasure of knowing/being/seeing/doing...\" [psychological/emotional pleasure/satiety only]"
+        "notes": "This root is also used as the **SATIATIVE (SAT) Bias Affix**: *“How satisfying...!”, “At least, the pleasure of knowing/being/seeing/doing...” [psychological/emotional pleasure/satiety only]"
     },
     {
         "root": "ŇC",

--- a/lexicon/4.5.8.json
+++ b/lexicon/4.5.8.json
@@ -17,7 +17,7 @@
         "root": "SŇ",
         "refers": "ORAL-NASAL REFLEX",
         "stems": [
-            "make oral sound of derisiveness (e.g., \"pfft\", \"pshhh\", etc.)",
+            "make oral sound of derisiveness (e.g., “pfft”, “pshhh”, etc.)",
             "drop jaw (i.e., open mouth suddenly in surprise/shock/pain)",
             "snort (e.g., in disgust)"
         ],

--- a/lexicon/4.5.9.json
+++ b/lexicon/4.5.9.json
@@ -55,7 +55,7 @@
         "stems": [
             "(one's) facial expression",
             "(one's) natural/relaxed/unconscious facial expression",
-            "a conscious/semi-conscious/affected facial expression, a \"look\""
+            "a conscious/semi-conscious/affected facial expression, a “look”"
         ],
         "see": "JW"
     },
@@ -63,9 +63,9 @@
         "root": "ḐBŘ",
         "refers": "ONES POSTURE",
         "stems": [
-            "straight / \"ramrod\" / \"good\" / upright / attentive posture",
+            "straight / “ramrod” / “good” / upright / attentive posture",
             "relaxed / slouched posture; to slouch, relax one's posture",
-            "stooped / \"poor\" posture"
+            "stooped / “poor” posture"
         ],
         "see": "JW"
     },
@@ -73,8 +73,8 @@
         "root": "ŠKV",
         "refers": "ATYPICAL FACIAL EXPRESSION",
         "stems": [
-            "\"scrunch up\" one's face in irritation/puzzlement/concentration",
-            "look of distraction / not paying attention / being \"far away\"",
+            "“scrunch up” one's face in irritation/puzzlement/concentration",
+            "look of distraction / not paying attention / being “far away”",
             "raise eyebrows due to encountering/considering something unexpected"
         ],
         "see": "JW"

--- a/lexicon/4.5.json
+++ b/lexicon/4.5.json
@@ -27,7 +27,7 @@
             "(to be) an act of keeping/bearing something in mind; to have in the back of one's mind",
             "(to be) a state of being down-to-earth or having one's bearings (or an act demonstrating such a trait); to do something indicative of or consistent with one having a natural well-rounded awareness or down-to-earth quality"
         ],
-        "notes": "Use the ICP extension or the SUD or OPL affixes with Stem 1 to signify \"to notice (something), take note of something\"\n\nThis root is also used as the **ATTENTIVE (ATE) Bias Affix**: *\"Well, whaddya know...\", \"Well, will you look at that...!\", \"Well, go figure...\", \"Who would've thought...?\", \"Well I'll be!\"*"
+        "notes": "Use the ICP extension or the SUD or OPL affixes with Stem 1 to signify “to notice (something), take note of something”\n\nThis root is also used as the **ATTENTIVE (ATE) Bias Affix**: *“Well, whaddya know...”, “Well, will you look at that...!”, “Well, go figure...”, “Who would've thought...?”, “Well I'll be!”*"
     },
     {
         "root": "MGŘ",

--- a/lexicon/5.2.json
+++ b/lexicon/5.2.json
@@ -10,7 +10,7 @@
                 "OBJ": "(to be) the target/victim of an object used (circumstantially) for harming/injuring/killing"
             },
             "(to be) an object/device/force designed/constructed specifically for the purpose of harming/injuring/killing a living entity; (to be) a weapon",
-            "(to be) an intangible or abstract entity used as a weapon (e.g., words, propaganda, one's intimidating/bullying behavior, one's passive-aggressive \"game-playing\", etc.)"
+            "(to be) an intangible or abstract entity used as a weapon (e.g., words, propaganda, one's intimidating/bullying behavior, one's passive-aggressive “game-playing”, etc.)"
         ]
     },
     {
@@ -377,7 +377,7 @@
         "stems": [
             "electromagnetic energy weapon (e.g., laser-based)",
             "atomic particle beam",
-            "\"disruptor\"-style weapon"
+            "“disruptor”-style weapon"
         ],
         "see": "XVL"
     },

--- a/lexicon/5.3.json
+++ b/lexicon/5.3.json
@@ -405,7 +405,7 @@
         "stems": [
             "spades",
             "500 (card game)",
-            "other \"trick-taking\" card game"
+            "other “trick-taking” card game"
         ],
         "see": "ŢSK"
     },
@@ -459,7 +459,7 @@
         "stems": [
             "switch / last card / two four jacks",
             "one-card",
-            "other \"shedding\"-type card game"
+            "other “shedding”-type card game"
         ],
         "see": "ŢSK"
     },
@@ -565,7 +565,7 @@
     {
         "root": "MFTL",
         "stems": [
-            "\"would you rather\" or similar choice-based game",
+            "“would you rather” or similar choice-based game",
             "Truth or Dare or similar game",
             "other party/parlor game"
         ],

--- a/lexicon/6.1.json
+++ b/lexicon/6.1.json
@@ -248,7 +248,7 @@
         "CSV": "(to be) an act of determining the degree of limpness/flaccidity; to determine the degree of pliancy/ductility/suppleness of something",
         "OBJ": "(to be) that which has a particular degree of pliancy/ductility/suppleness"
       },
-      "(to be) a particular degree of deformability or \"dentability\" (i.e., how easily deformed or dented a material is)",
+      "(to be) a particular degree of deformability or “dentability” (i.e., how easily deformed or dented a material is)",
       "(to be) a particular degree of spreadability"
     ]
   },
@@ -324,7 +324,7 @@
   },
   {
     "root": "KV",
-    "refers": "\"COLDNESS / COOLING / FREEZING\" Derivations: air conditioner, refrigerator",
+    "refers": "“COLDNESS / COOLING / FREEZING” Derivations: air conditioner, refrigerator",
     "stems": [
       {
         "BSC": "(to be) a state/act of being/becoming cold/frigid; to be(come) cold/frigid",

--- a/lexicon/6.2.json
+++ b/lexicon/6.2.json
@@ -249,7 +249,7 @@
   },
   {
     "root": "LPS",
-    "refers": "\"PHYSICAL MASS\" Associated Affix: MSS",
+    "refers": "“PHYSICAL MASS” Associated Affix: MSS",
     "stems": [
       {
         "BSC": "(to be) a state/act of having a certain mass",
@@ -545,7 +545,7 @@
   {
     "root": "RŠPY",
     "refers": "LUMINOUS FLUX",
-    "notes": "i.e. \"amount\" of visible light emitted by a source, as measured by luminous intensity per solid angle",
+    "notes": "i.e. “amount” of visible light emitted by a source, as measured by luminous intensity per solid angle",
     "see": "ŇŠP"
   },
   {
@@ -643,7 +643,7 @@
         "OBJ": "(to be) the particular size of an entity; to measure the size of an entity"
       },
       "(to be/manifest a) degree of spatial size, i.e., volume of space (whether uni-dimensional, 2-D, or 3-D)",
-      "(to be/manifest a) degree of temporal \"size\" (= an \"amount\" of time)"
+      "(to be/manifest a) degree of temporal “size” (= an “amount” of time)"
     ],
     "notes": "(use SUF/EXN/EXD, etc. affixes to specify degree)\n\nMorphological derivations: enlarge, swell, expand (in volume), grow (in size); shrink, make smaller"
   },

--- a/lexicon/6.3.json
+++ b/lexicon/6.3.json
@@ -18,8 +18,8 @@
     "refers": "EARTH / MOON / NAMED MICRO-PLANET",
     "stems": [
       {
-        "BSC": "(to be) the Earth/Terra (as both a planetary body and a \"world\" encompassing a particular biosphere/ecosystem and civilization)",
-        "CTE": "(to be) \"the world\" [i.e., the Terran-based biosphere, ecosystem, environment and civilization which Terran life inhabits]",
+        "BSC": "(to be) the Earth/Terra (as both a planetary body and a “world” encompassing a particular biosphere/ecosystem and civilization)",
+        "CTE": "(to be) “the world” [i.e., the Terran-based biosphere, ecosystem, environment and civilization which Terran life inhabits]",
         "CSV": "(to be) the physical planetary body itself that constitutes the planet Earth/Terra",
         "OBJ": "(to be) the orbit(al path) of the planet Earth/Terra"
       },
@@ -75,7 +75,7 @@
     "stems": [
       {
         "BSC": "(to be) a volume of celestial (i.e., interplanetary, interstellar/intergalactic) space; to be (situated) in space",
-        "CTE": "(to be) the state/quality of three-dimensional \"spaciousness\" or \"room\" within a volume of celestial space",
+        "CTE": "(to be) the state/quality of three-dimensional “spaciousness” or “room” within a volume of celestial space",
         "CSV": "(to be) the physical body/structure/medium of celestial space; to occur or be situated in celestial space",
         "OBJ": "(to be) a location in space (relative to celestial bodies within that space)"
       },
@@ -104,10 +104,10 @@
       {
         "BSC": "(to be) an atom",
         "CTE": "(to be) the state of an atom in terms of its interaction (or lack thereof) with other atoms; for an atom to interact (via atomic bonding) with other atoms",
-        "CSV": "(to be) the tangible/physical \"embodiment\"/manifestation of an atom",
+        "CSV": "(to be) the tangible/physical “embodiment”/manifestation of an atom",
         "OBJ": "(to be) a component/attribute/aspect of an atom (i.e., a particle, a charge, a force, etc.)"
       },
-      "(to be) the electron cloud of an atom (i.e., set of electron shells with \"orbiting\" electrons) of an atom",
+      "(to be) the electron cloud of an atom (i.e., set of electron shells with “orbiting” electrons) of an atom",
       "(to be) an orbital state (i.e., state and behavior of an electron based on its orbital probability distribution)"
     ]
   },
@@ -118,7 +118,7 @@
       {
         "BSC": "(to be) the nucleus of an atom",
         "CTE": "(to be) the state of an atomic nucleus in terms of its interaction (or lack thereof) with other atoms; for an atom to interact (via atomic bonding) with other atoms",
-        "CSV": "(to be) the tangible/physical \"embodiment\"/manifestation of an atomic nucleus",
+        "CSV": "(to be) the tangible/physical “embodiment”/manifestation of an atomic nucleus",
         "OBJ": "(to be) a component/attribute/aspect of an atomic nucleus (i.e., a particle, a charge, a force, etc.)"
       },
       "(to be) a nuclide (i.e., specific configuration of Z- value, N-value, and energy state for a particular atomic nucleus)",
@@ -136,8 +136,8 @@
     "stems": [
       {
         "BSC": "(to be) a sub-atomic particle",
-        "CTE": "(to be) the sub-atomic state or \"force\" (i.e., interaction) mediated or maintained by a sub- atomic particle",
-        "CSV": "(to be) the tangible/physical \"embodiment\"/manifestation/\"stuff\" of a sub-atomic particle",
+        "CTE": "(to be) the sub-atomic state or “force” (i.e., interaction) mediated or maintained by a sub- atomic particle",
+        "CSV": "(to be) the tangible/physical “embodiment”/manifestation/“stuff” of a sub-atomic particle",
         "OBJ": "(to be) an attribute of sub-atomic particle (e.g., mass, charge, spin, angular momentum, etc.)"
       },
       "(to be) an elementary particle (i.e., fermion or boson)",
@@ -174,7 +174,7 @@
     "refers": "BOSON",
     "stems": [
       "boson",
-      "\"string\" (from string theory) [CTE Specification = vibration of \"string\"]",
+      "“string” (from string theory) [CTE Specification = vibration of “string”]",
       "acceleron (i.e., hypothetical particle associated with dark energy theory)"
     ],
     "see": "LŢK"
@@ -211,25 +211,25 @@
   },
   {
     "root": "Q3",
-    "refers": "\"OTHER SUB-ATOMIC PARTICLE\" I",
+    "refers": "“OTHER SUB-ATOMIC PARTICLE” I",
     "stems": ["pion", "kaon", "theta meson"],
     "see": "LŢK"
   },
   {
     "root": "Q4",
-    "refers": "\"OTHER SUB-ATOMIC PARTICLE\" II",
+    "refers": "“OTHER SUB-ATOMIC PARTICLE” II",
     "stems": ["rho meson", "eta meson", "D-meson"],
     "see": "LŢK"
   },
   {
     "root": "Q5",
-    "refers": "\"OTHER SUB-ATOMIC PARTICLE\" III",
+    "refers": "“OTHER SUB-ATOMIC PARTICLE” III",
     "stems": ["B-meson", "omega meson", "phi meson"],
     "see": "LŢK"
   },
   {
     "root": "Q6",
-    "refers": "\"OTHER SUB-ATOMIC PARTICLE\" IV",
+    "refers": "“OTHER SUB-ATOMIC PARTICLE” IV",
     "stems": [
       "psion",
       "upsilon meson",
@@ -275,8 +275,8 @@
         "CSV": "(to be) an act of obtaining/providing/disseminating air (into a volume of space); to get air, give air, let air in",
         "OBJ": "(to be) the air one breathes"
       },
-      "(to be) the state/act/process of there being \"fresh\" air (i.e., air let in from an external source/outside to replenish the recycled or \"stale\" air in a location)",
-      "(to be) the state/act/process of there being \"stale\" air (i.e., air with a lowered oxygen content and/or higher CO₂ concentration and/or pollutants due to breathing in an enclosed space, air pollution, etc.)"
+      "(to be) the state/act/process of there being “fresh” air (i.e., air let in from an external source/outside to replenish the recycled or “stale” air in a location)",
+      "(to be) the state/act/process of there being “stale” air (i.e., air with a lowered oxygen content and/or higher CO₂ concentration and/or pollutants due to breathing in an enclosed space, air pollution, etc.)"
     ]
   },
   {
@@ -697,7 +697,7 @@
       "(to be) the state/act/process of there being a particular amount of air pressure in the atmosphere; to be a certain atmospheric pressure [i.e., at any given altitude)",
       "(to be) the state/act/process of there being a cloud (in the sky); to be a cloud (in the sky), for a cloud (in the sky) to be present"
     ],
-    "notes": "for \"fog; to be foggy\", concatenate Stem 2 of -KTH- (\"ground/surface of Earth\") in LOCATIVE format into Stem 3 of the above root (\"cloud\")"
+    "notes": "for “fog; to be foggy”, concatenate Stem 2 of -KTH- (“ground/surface of Earth”) in LOCATIVE format into Stem 3 of the above root (“cloud”)"
   },
   {
     "root": "TTH",
@@ -719,7 +719,7 @@
       "(to be) an amount of snow; to snow [CPT = fallen snow]",
       "(to be) an amount of hail; to hail [CPT = ice on the ground]"
     ],
-    "notes": "for \"fog; to be foggy\", concatenate Stem 2 of -KTH- (\"ground/surface of Earth\") in LOCATIVE format into Stem 3 of -FTH- (\"cloud\")"
+    "notes": "for “fog; to be foggy”, concatenate Stem 2 of -KTH- (“ground/surface of Earth”) in LOCATIVE format into Stem 3 of -FTH- (“cloud”)"
   },
   {
     "root": "FPH",
@@ -788,7 +788,7 @@
         "OBJ": "(to be) the atmospheric state of aerosolized water vapor conducive to/needed for seeing a rainbow"
       },
       "(to be) a state of there being a visible aurora",
-      "(to be) a state of there being sunlight reflected from interplanetary dust particles visible under certain conditions (e.g., zodiacal light (\"false dawn\"), gegenschein/counterglow)"
+      "(to be) a state of there being sunlight reflected from interplanetary dust particles visible under certain conditions (e.g., zodiacal light (“false dawn”), gegenschein/counterglow)"
     ]
   }
 ]

--- a/lexicon/6.4.1.json
+++ b/lexicon/6.4.1.json
@@ -16,10 +16,10 @@
         "OBJ": "(to be) an entity having zero-dimensionality; (to be) a Euclidean point; to have geometrically no length, area or volume, i.e., to be a Euclidean point"
       },
       {
-        "BSC": "(to be) the baseline \"zero\"-state or null-state in a sequence, hierarchy, gradient, pattern, etc.",
-        "CTE": "(to be) the state of being the baseline \"zero\"-state or null-state",
-        "CSV": "(to be) a process which determines/identifies an entity's being the baseline \"zero\"-state or null-state",
-        "OBJ": "(to be) the entity/party in the baseline \"zero\"-state or null- state in a sequence, hierarchy, gradient, pattern, etc."
+        "BSC": "(to be) the baseline “zero”-state or null-state in a sequence, hierarchy, gradient, pattern, etc.",
+        "CTE": "(to be) the state of being the baseline “zero”-state or null-state",
+        "CSV": "(to be) a process which determines/identifies an entity's being the baseline “zero”-state or null-state",
+        "OBJ": "(to be) the entity/party in the baseline “zero”-state or null- state in a sequence, hierarchy, gradient, pattern, etc."
       }
     ],
     "notes": "Associated Affix: XX0"
@@ -628,6 +628,6 @@
         "OBJ": "(to be) the (desired) transformation precipitated by performance/application of an abstract operation"
       }
     ],
-    "notes": "Use an appropriate degree of the OAU affix with the stems of the above root to generate a term for \"argument\" or \"abstract entity\" meaning a logical participant or referenced entity within a logical argument, e.g., \"In linguistics, we speak of the various nouns within a sentence as being *arguments* to a verb.\""
+    "notes": "Use an appropriate degree of the OAU affix with the stems of the above root to generate a term for “argument” or “abstract entity” meaning a logical participant or referenced entity within a logical argument, e.g., “In linguistics, we speak of the various nouns within a sentence as being *arguments* to a verb.”"
   }
 ]

--- a/lexicon/6.4.2.json
+++ b/lexicon/6.4.2.json
@@ -7,7 +7,7 @@
         "BSC": "(to be/manifest) a two-dimensional shape or outline form — [both the shape and the entity manifesting that shape]",
         "CTE": "(to be) the entity manifesting a particular 2-D shape or outline form",
         "CSV": "(to be/manifest) a two-dimensional shape or outline form",
-        "OBJ": "(to be) the background or \"negative space\" behind a 2-dimensional shape or outline form"
+        "OBJ": "(to be) the background or “negative space” behind a 2-dimensional shape or outline form"
       },
       "(to be/manifest) a three-dimensional shape/form",
       "(to be a) figure (reminiscent of something) based on shape/form"
@@ -50,7 +50,7 @@
         "OBJ": "(be) an object/entity which manifests the particular (quasi-)linear outline shape"
       },
       "(be) the (quasi-)planar extension (in 3-dimensional space) of the Stem 1 linear shape, e.g., a hemisphere shape based on the Stem-1 linear shape of an arc, or a notch- or wedge-shaped indentation based on the  Stem-1 linear shape of a V-shape.",
-      "(be) the \"negative\" space delineated by a (quasi-)linear outline shape, e.g., the pointed area of one's plane of vision created as the negative space set off by something in the foreground having a V-shaped outline."
+      "(be) the “negative” space delineated by a (quasi-)linear outline shape, e.g., the pointed area of one's plane of vision created as the negative space set off by something in the foreground having a V-shaped outline."
     ]
   },
   {
@@ -286,7 +286,7 @@
         "OBJ": "(be) an object/entity which manifests the particular closed (quasi-)linear outline shape"
       },
       "(be) a (quasi-)planar object/entity whose edge(s) constitute the Stem 1 closed linear shape, e.g., a cookie in the shape of a circle, or a stop-sign in the shape of an octagon.",
-      "(be) the background \"negative\" space delineated by a closed (quasi-)linear outline shape, e.g., the area of one's plane of vision with a \"hole\" in it, created as the negative space set off by something in the foreground having a closed-linear outline."
+      "(be) the background “negative” space delineated by a closed (quasi-)linear outline shape, e.g., the area of one's plane of vision with a “hole” in it, created as the negative space set off by something in the foreground having a closed-linear outline."
     ]
   },
   {
@@ -581,7 +581,7 @@
   },
   {
     "root": "SSKR",
-    "refers": "3-DIMENSIONAL IRREGULAR \"AMOEBOID\" SHAPE",
+    "refers": "3-DIMENSIONAL IRREGULAR “AMOEBOID” SHAPE",
     "see": "TĻK"
   },
   {

--- a/lexicon/6.4.3.json
+++ b/lexicon/6.4.3.json
@@ -805,7 +805,7 @@
   },
   {
     "root": "LCNY",
-    "refers": "sugar (any molecular \"-ose\" compound)",
+    "refers": "sugar (any molecular “-ose” compound)",
     "see": "RẒB"
   },
   {
@@ -1748,7 +1748,7 @@
     "refers": "SUBSTANCE / MATERIAL / WHAT SOMETHING CONSISTS OF OR IS COMPOSED/MADE OF",
     "stems": [
       {
-        "BSC": "(to be a) an instance/amount of a material substance; (to be a) manifestation of matter/material/ \"stuff\" / something material — [both the substance itself and the form/entity consisting thereof]",
+        "BSC": "(to be a) an instance/amount of a material substance; (to be a) manifestation of matter/material/ “stuff” / something material — [both the substance itself and the form/entity consisting thereof]",
         "CTE": "(to be) the material substance of which something consists or is made; something material",
         "CSV": "(to be) a form taken by something material, the shape/form of something material",
         "OBJ": "(to be) an object/entity made from or consisting of a particular material"
@@ -1784,7 +1784,7 @@
   },
   {
     "root": "ŇŽKW",
-    "refers": "polystyrene foam (\"styrofoam\")",
+    "refers": "polystyrene foam (“styrofoam”)",
     "see": "SY"
   },
   {

--- a/lexicon/7.1.json
+++ b/lexicon/7.1.json
@@ -299,7 +299,7 @@
   },
   {
     "root": "ŠBW",
-    "refers": "\"SUGAR\" [i.e., as foodstuff, not as chemical compound]",
+    "refers": "“SUGAR” [i.e., as foodstuff, not as chemical compound]",
     "see": "LKS"
   },
   {

--- a/lexicon/7.2.1.1.json
+++ b/lexicon/7.2.1.1.json
@@ -49,7 +49,7 @@
   },
   {
     "root": "LÇPW",
-    "refers": "\"TARSAL BONES\" I",
+    "refers": "“TARSAL BONES” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **calcaneus bone** [both the material/physical aspect and the functional aspect thereof]",
@@ -73,7 +73,7 @@
   },
   {
     "root": "LÇTW",
-    "refers": "\"TARSAL BONES\" II",
+    "refers": "“TARSAL BONES” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **metatarsal bone** [both the material/physical aspect and the functional aspect thereof]",
@@ -121,7 +121,7 @@
   },
   {
     "root": "LÇTY",
-    "refers": "\"CARPAL BONES\" I",
+    "refers": "“CARPAL BONES” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **scaphoid bone** [both the material/physical aspect and the functional aspect thereof]",
@@ -145,7 +145,7 @@
   },
   {
     "root": "LÇTL",
-    "refers": "\"CARPAL BONES\" II",
+    "refers": "“CARPAL BONES” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **metacarpal bone** [both the material/physical aspect and the functional aspect thereof]",
@@ -457,7 +457,7 @@
   },
   {
     "root": "LTÇG",
-    "refers": "\"JAW BONES\" I",
+    "refers": "“JAW BONES” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **mandible/dentary bone** [both the material/physical aspect and the functional aspect thereof]",
@@ -481,7 +481,7 @@
   },
   {
     "root": "LTÇB",
-    "refers": "\"JAW BONES\" II",
+    "refers": "“JAW BONES” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **articular bone** [both the material/physical aspect and the functional aspect thereof]",
@@ -529,7 +529,7 @@
   },
   {
     "root": "LTÇW",
-    "refers": "\"SKULL BONES\" I",
+    "refers": "“SKULL BONES” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **temporal bone** [both the material/physical aspect and the functional aspect thereof]",
@@ -553,7 +553,7 @@
   },
   {
     "root": "LTÇL",
-    "refers": "\"SKULL BONES\" II",
+    "refers": "“SKULL BONES” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **vomer bone** [both the material/physical aspect and the functional aspect thereof]",
@@ -577,7 +577,7 @@
   },
   {
     "root": "LTÇR",
-    "refers": "\"SKULL BONES\" III",
+    "refers": "“SKULL BONES” III",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **hard palate [i.e., the bone underlying the tissue covering the hard palate]** [both the material/physical aspect and the functional aspect thereof]",
@@ -601,7 +601,7 @@
   },
   {
     "root": "LTÇV",
-    "refers": "\"SKULL BONES\" IV",
+    "refers": "“SKULL BONES” IV",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **frontal bone** [both the material/physical aspect and the functional aspect thereof]",
@@ -1141,7 +1141,7 @@
   },
   {
     "root": "MZPW",
-    "refers": "\"FOREARM MUSCLE\" I",
+    "refers": "“FOREARM MUSCLE” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **flexor carpi radialis** [both the material/physical aspect and the functional aspect thereof]",
@@ -1166,7 +1166,7 @@
   },
   {
     "root": "MZPY",
-    "refers": "\"FOREARM MUSCLE\" II",
+    "refers": "“FOREARM MUSCLE” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **flexor carpi ulnaris** [both the material/physical aspect and the functional aspect thereof]",
@@ -1191,7 +1191,7 @@
   },
   {
     "root": "MZPL",
-    "refers": "\"FOREARM MUSCLE\" III",
+    "refers": "“FOREARM MUSCLE” III",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **palmaris longus** [both the material/physical aspect and the functional aspect thereof]",
@@ -1216,7 +1216,7 @@
   },
   {
     "root": "MZPR",
-    "refers": "\"FOREARM MUSCLE\" IV",
+    "refers": "“FOREARM MUSCLE” IV",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **extensor carpi radialis longus** [both the material/physical aspect and the functional aspect thereof]",
@@ -1241,7 +1241,7 @@
   },
   {
     "root": "MZPF",
-    "refers": "\"FOREARM MUSCLE\" V",
+    "refers": "“FOREARM MUSCLE” V",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **brachioradialis** [both the material/physical aspect and the functional aspect thereof]",
@@ -1266,7 +1266,7 @@
   },
   {
     "root": "MZPŢ",
-    "refers": "\"FOREARM MUSCLE\" VI",
+    "refers": "“FOREARM MUSCLE” VI",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **extensor pollicis** [both the material/physical aspect and the functional aspect thereof]",
@@ -1291,7 +1291,7 @@
   },
   {
     "root": "MZKW",
-    "refers": "\"ANTERIOR THIGH MUSCLE\" I",
+    "refers": "“ANTERIOR THIGH MUSCLE” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **vastus lateralis** [both the material/physical aspect and the functional aspect thereof]",
@@ -1316,7 +1316,7 @@
   },
   {
     "root": "MZKY",
-    "refers": "\"ANTERIOR THIGH MUSCLE\" II",
+    "refers": "“ANTERIOR THIGH MUSCLE” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **rectus femoris** [both the material/physical aspect and the functional aspect thereof]",
@@ -1341,7 +1341,7 @@
   },
   {
     "root": "MZKL",
-    "refers": "\"ANTERIOR THIGH MUSCLE\" III",
+    "refers": "“ANTERIOR THIGH MUSCLE” III",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **sartorius** [both the material/physical aspect and the functional aspect thereof]",
@@ -1516,7 +1516,7 @@
   },
   {
     "root": "MVG",
-    "refers": "\"ARM MUSCLE\" I",
+    "refers": "“ARM MUSCLE” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **biceps brachii** [both the material/physical aspect and the functional aspect thereof]",
@@ -1541,7 +1541,7 @@
   },
   {
     "root": "MVGL",
-    "refers": "\"ARM MUSCLE\" II",
+    "refers": "“ARM MUSCLE” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **triceps brachii (long head)** [both the material/physical aspect and the functional aspect thereof]",
@@ -1566,7 +1566,7 @@
   },
   {
     "root": "MVGR",
-    "refers": "\"ARM MUSCLE\" III",
+    "refers": "“ARM MUSCLE” III",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **coracobrachialis** [both the material/physical aspect and the functional aspect thereof]",
@@ -1716,7 +1716,7 @@
   },
   {
     "root": "MŽKŘ",
-    "refers": "\"PERINEAL MUSCLE\" I",
+    "refers": "“PERINEAL MUSCLE” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **ischiocavernosus muscle** [both the material/physical aspect and the functional aspect thereof]",
@@ -1741,7 +1741,7 @@
   },
   {
     "root": "MŽKÇ",
-    "refers": "\"PERINEAL MUSCLE\" II",
+    "refers": "“PERINEAL MUSCLE” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **anal sphincter** [both the material/physical aspect and the functional aspect thereof]",
@@ -1916,7 +1916,7 @@
   },
   {
     "root": "LŽBR",
-    "refers": "\"BACK MUSCLES\" I",
+    "refers": "“BACK MUSCLES” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **trapezius** [both the material/physical aspect and the functional aspect thereof]",
@@ -1941,7 +1941,7 @@
   },
   {
     "root": "LŽBŘ",
-    "refers": "\"BACK MUSCLES\" II",
+    "refers": "“BACK MUSCLES” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **serratus posterior inferior** [both the material/physical aspect and the functional aspect thereof]",
@@ -1991,7 +1991,7 @@
   },
   {
     "root": "LŽGY",
-    "refers": "\"INNER CHEST MUSCLE\" I",
+    "refers": "“INNER CHEST MUSCLE” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **diaphragm** [both the material/physical aspect and the functional aspect thereof]",
@@ -2016,7 +2016,7 @@
   },
   {
     "root": "LŽGL",
-    "refers": "\"INNER CHEST MUSCLE\" II",
+    "refers": "“INNER CHEST MUSCLE” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **intercostal muscle** [both the material/physical aspect and the functional aspect thereof]",
@@ -2216,7 +2216,7 @@
   },
   {
     "root": "MŽT",
-    "refers": "\"NECK MUSCLE\" I",
+    "refers": "“NECK MUSCLE” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **longus colli** [both the material/physical aspect and the functional aspect thereof]",
@@ -2241,7 +2241,7 @@
   },
   {
     "root": "MŽTW",
-    "refers": "\"NECK MUSCLE\" II",
+    "refers": "“NECK MUSCLE” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **scalene muscle** [both the material/physical aspect and the functional aspect thereof]",
@@ -2266,7 +2266,7 @@
   },
   {
     "root": "MŽTY",
-    "refers": "\"NECK MUSCLE\" III",
+    "refers": "“NECK MUSCLE” III",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **platysma** [both the material/physical aspect and the functional aspect thereof]",
@@ -2291,7 +2291,7 @@
   },
   {
     "root": "MŽTL",
-    "refers": "\"THROAT MUSCLE\" I",
+    "refers": "“THROAT MUSCLE” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **digastric** [both the material/physical aspect and the functional aspect thereof]",
@@ -2316,7 +2316,7 @@
   },
   {
     "root": "MŽTR",
-    "refers": "\"THROAT MUSCLE\" II",
+    "refers": "“THROAT MUSCLE” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **omohyoid** [both the material/physical aspect and the functional aspect thereof]",
@@ -2341,7 +2341,7 @@
   },
   {
     "root": "MŽTŘ",
-    "refers": "\"THROAT MUSCLE\" III",
+    "refers": "“THROAT MUSCLE” III",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **sternohyoid** [both the material/physical aspect and the functional aspect thereof]",
@@ -2391,7 +2391,7 @@
   },
   {
     "root": "MŽPW",
-    "refers": "\"PHARYNGEAL/TRACHEAL MUSCLE\" I",
+    "refers": "“PHARYNGEAL/TRACHEAL MUSCLE” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **inferior pharyngeal constrictor** [both the material/physical aspect and the functional aspect thereof]",
@@ -2416,7 +2416,7 @@
   },
   {
     "root": "MŽPY",
-    "refers": "\"PHARYNGEAL/TRACHEAL MUSCLE\" II",
+    "refers": "“PHARYNGEAL/TRACHEAL MUSCLE” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **stylopharyngeus** [both the material/physical aspect and the functional aspect thereof]",
@@ -2441,7 +2441,7 @@
   },
   {
     "root": "MŽPL",
-    "refers": "\"TONGUE MUSCLE & TISSUE\" I",
+    "refers": "“TONGUE MUSCLE & TISSUE” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **styloglossus** [both the material/physical aspect and the functional aspect thereof]",
@@ -2466,7 +2466,7 @@
   },
   {
     "root": "MŽPR",
-    "refers": "\"TONGUE MUSCLE & TISSUE\" II",
+    "refers": "“TONGUE MUSCLE & TISSUE” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **superior longitudinal muscle** [both the material/physical aspect and the functional aspect thereof]",
@@ -2491,7 +2491,7 @@
   },
   {
     "root": "MŽPŘ",
-    "refers": "\"TONGUE MUSCLE & TISSUE\" III",
+    "refers": "“TONGUE MUSCLE & TISSUE” III",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **vertical muscle of the tongue** [both the material/physical aspect and the functional aspect thereof]",
@@ -2516,7 +2516,7 @@
   },
   {
     "root": "MŽPF",
-    "refers": "\"SOFT PALATE\" I",
+    "refers": "“SOFT PALATE” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **tensor veli palatini** [both the material/physical aspect and the functional aspect thereof]",
@@ -2541,7 +2541,7 @@
   },
   {
     "root": "MŽPŢ",
-    "refers": "\"SOFT PALATE\" II",
+    "refers": "“SOFT PALATE” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **musculus uvulae (uvula)** [both the material/physical aspect and the functional aspect thereof]",
@@ -2666,7 +2666,7 @@
   },
   {
     "root": "MŽN",
-    "refers": "\"NASAL MUSCLE\" I",
+    "refers": "“NASAL MUSCLE” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **procerus** [both the material/physical aspect and the functional aspect thereof]",
@@ -2691,7 +2691,7 @@
   },
   {
     "root": "MŽNW",
-    "refers": "\"NASAL MUSCLE\" II",
+    "refers": "“NASAL MUSCLE” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **alar nasalis** [both the material/physical aspect and the functional aspect thereof]",
@@ -2716,7 +2716,7 @@
   },
   {
     "root": "MŽNY",
-    "refers": "\"NASAL MUSCLE\" III",
+    "refers": "“NASAL MUSCLE” III",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **dilator naris anterior** [both the material/physical aspect and the functional aspect thereof]",
@@ -2766,7 +2766,7 @@
   },
   {
     "root": "MÇFW",
-    "refers": "\"EYEBALL MUSCLE\" I",
+    "refers": "“EYEBALL MUSCLE” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **superior rectus** [both the material/physical aspect and the functional aspect thereof]",
@@ -2791,7 +2791,7 @@
   },
   {
     "root": "MÇFY",
-    "refers": "\"EYEBALL MUSCLE\" II",
+    "refers": "“EYEBALL MUSCLE” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **levator palpebrae superioris** [both the material/physical aspect and the functional aspect thereof]",
@@ -2816,7 +2816,7 @@
   },
   {
     "root": "MÇFL",
-    "refers": "\"HEAD MUSCLE & TISSUE\" I",
+    "refers": "“HEAD MUSCLE & TISSUE” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **frontalis** [both the material/physical aspect and the functional aspect thereof]",
@@ -2841,7 +2841,7 @@
   },
   {
     "root": "MÇFR",
-    "refers": "\"HEAD MUSCLE & TISSUE\" II",
+    "refers": "“HEAD MUSCLE & TISSUE” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **temporal fascia** [both the material/physical aspect and the functional aspect thereof]",
@@ -2966,7 +2966,7 @@
   },
   {
     "root": "VZKW",
-    "refers": "\"FOOT LIGAMENT\" I",
+    "refers": "“FOOT LIGAMENT” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **plantar interphalangeal ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -2991,7 +2991,7 @@
   },
   {
     "root": "VZKY",
-    "refers": "\"FOOT LIGAMENT\" II",
+    "refers": "“FOOT LIGAMENT” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **collateral interphalangeal ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3016,7 +3016,7 @@
   },
   {
     "root": "VZKL",
-    "refers": "\"FOOT LIGAMENT\" III",
+    "refers": "“FOOT LIGAMENT” III",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **plantar intermetatarsal/metatarsal ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3041,7 +3041,7 @@
   },
   {
     "root": "VZKR",
-    "refers": "\"FOOT LIGAMENT\" IV",
+    "refers": "“FOOT LIGAMENT” IV",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **dorsal intermetatarsal/metatarsal ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3066,7 +3066,7 @@
   },
   {
     "root": "VZKŘ",
-    "refers": "\"FOOT LIGAMENT\" V",
+    "refers": "“FOOT LIGAMENT” V",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **plantar cuneonavicular ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3091,7 +3091,7 @@
   },
   {
     "root": "VZKÇ",
-    "refers": "\"FOOT LIGAMENT\" VI",
+    "refers": "“FOOT LIGAMENT” VI",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **dorsal cuneonavicular ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3116,7 +3116,7 @@
   },
   {
     "root": "VZKF",
-    "refers": "\"FOOT LIGAMENT\" VII",
+    "refers": "“FOOT LIGAMENT” VII",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **plantar calcaneonavicular/spring ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3141,7 +3141,7 @@
   },
   {
     "root": "VZKŢ",
-    "refers": "\"FOOT LIGAMENT\" VIII",
+    "refers": "“FOOT LIGAMENT” VIII",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **plantar or long plantar calcaneocuboid ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3166,7 +3166,7 @@
   },
   {
     "root": "VZKV",
-    "refers": "\"FOOT LIGAMENT\" IX",
+    "refers": "“FOOT LIGAMENT” IX",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **anterior talocalcaneal ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3191,7 +3191,7 @@
   },
   {
     "root": "VZKM",
-    "refers": "\"FOOT LIGAMENT\" X",
+    "refers": "“FOOT LIGAMENT” X",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **posterior talocalcaneal ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3216,7 +3216,7 @@
   },
   {
     "root": "VZKN",
-    "refers": "\"FOOT LIGAMENT\" XI",
+    "refers": "“FOOT LIGAMENT” XI",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **anterior tibiotalar ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3241,7 +3241,7 @@
   },
   {
     "root": "VZKH",
-    "refers": "\"FOOT LIGAMENT\" XII",
+    "refers": "“FOOT LIGAMENT” XII",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **anterior talofibular ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3316,7 +3316,7 @@
   },
   {
     "root": "KŢC",
-    "refers": "\"KNEE LIGAMENT\" I",
+    "refers": "“KNEE LIGAMENT” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **anterior cruciate ligament / cranial cruciate ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3341,7 +3341,7 @@
   },
   {
     "root": "KŢCW",
-    "refers": "\"KNEE LIGAMENT\" II",
+    "refers": "“KNEE LIGAMENT” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **posterior cruciate ligament / caudal cruciate ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3366,7 +3366,7 @@
   },
   {
     "root": "KŢCY",
-    "refers": "\"KNEE LIGAMENT\" III",
+    "refers": "“KNEE LIGAMENT” III",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **anterior meniscofemoral ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3391,7 +3391,7 @@
   },
   {
     "root": "KŢCM",
-    "refers": "\"KNEE LIGAMENT\" IV",
+    "refers": "“KNEE LIGAMENT” IV",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **posterior meniscofemoral ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3441,7 +3441,7 @@
   },
   {
     "root": "KSLW",
-    "refers": "\"HIP LIGAMENT\" I",
+    "refers": "“HIP LIGAMENT” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **iliofemoral ligament / Y-ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3466,7 +3466,7 @@
   },
   {
     "root": "KSLY",
-    "refers": "\"HIP LIGAMENT\" II",
+    "refers": "“HIP LIGAMENT” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **head of the femur ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3566,7 +3566,7 @@
   },
   {
     "root": "KŠLW",
-    "refers": "\"PELVIC LIGAMENT\" I",
+    "refers": "“PELVIC LIGAMENT” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **anterior sacroiliac ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3591,7 +3591,7 @@
   },
   {
     "root": "KŠLY",
-    "refers": "\"PELVIC LIGAMENT\" II",
+    "refers": "“PELVIC LIGAMENT” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **superior pubic ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3641,7 +3641,7 @@
   },
   {
     "root": "BZLW",
-    "refers": "\"THORACO-VERTEBRAL LIGAMENT\" I",
+    "refers": "“THORACO-VERTEBRAL LIGAMENT” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **anterior sacrococcygeal ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3666,7 +3666,7 @@
   },
   {
     "root": "GZLW",
-    "refers": "\"THORACO-VERTEBRAL LIGAMENT\" II",
+    "refers": "“THORACO-VERTEBRAL LIGAMENT” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **costotransverse ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3691,7 +3691,7 @@
   },
   {
     "root": "ẒLW",
-    "refers": "\"THORACO-VERTEBRAL LIGAMENT\" III",
+    "refers": "“THORACO-VERTEBRAL LIGAMENT” III",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **intra-articular sternocostal ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3716,7 +3716,7 @@
   },
   {
     "root": "BZLY",
-    "refers": "\"VERTEBRAL LIGAMENT\" I",
+    "refers": "“VERTEBRAL LIGAMENT” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **iliolumbar ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3741,7 +3741,7 @@
   },
   {
     "root": "GZLY",
-    "refers": "\"VERTEBRAL LIGAMENT\" II",
+    "refers": "“VERTEBRAL LIGAMENT” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **cruciate ligament of atlas (transverse ligament of atlas)** [both the material/physical aspect and the functional aspect thereof]",
@@ -3766,7 +3766,7 @@
   },
   {
     "root": "ẒLY",
-    "refers": "\"VERTEBRAL LIGAMENT\" III",
+    "refers": "“VERTEBRAL LIGAMENT” III",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **anterior longitudinal ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3791,7 +3791,7 @@
   },
   {
     "root": "JLY",
-    "refers": "\"VERTEBRAL LIGAMENT\" IV",
+    "refers": "“VERTEBRAL LIGAMENT” IV",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **supraspinous (nuchal) ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3891,7 +3891,7 @@
   },
   {
     "root": "KŢTW",
-    "refers": "\"HAND LIGAMENT\" I",
+    "refers": "“HAND LIGAMENT” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **collateral interphalangeal ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3916,7 +3916,7 @@
   },
   {
     "root": "KŢTY",
-    "refers": "\"HAND LIGAMENT\" II",
+    "refers": "“HAND LIGAMENT” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **palmar interphalangeal ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3941,7 +3941,7 @@
   },
   {
     "root": "KŢTL",
-    "refers": "\"HAND LIGAMENT\" III",
+    "refers": "“HAND LIGAMENT” III",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **dorsal carpometacarpal ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3966,7 +3966,7 @@
   },
   {
     "root": "KŢTR",
-    "refers": "\"HAND LIGAMENT\" IV",
+    "refers": "“HAND LIGAMENT” IV",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **palmar carpometacarpal ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -3991,7 +3991,7 @@
   },
   {
     "root": "KŢTŘ",
-    "refers": "\"HAND LIGAMENT\" V",
+    "refers": "“HAND LIGAMENT” V",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **radiate carpal ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -4016,7 +4016,7 @@
   },
   {
     "root": "KŢTÇ",
-    "refers": "\"HAND LIGAMENT\" VI",
+    "refers": "“HAND LIGAMENT” VI",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **dorsal radiocarpal ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -4041,7 +4041,7 @@
   },
   {
     "root": "KŢTH",
-    "refers": "\"OTHER HAND/WRIST TISSUE\" I",
+    "refers": "“OTHER HAND/WRIST TISSUE” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **palmar radiocarpal ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -4066,7 +4066,7 @@
   },
   {
     "root": "PŢTW",
-    "refers": "\"OTHER HAND/WRIST TISSUE\" II",
+    "refers": "“OTHER HAND/WRIST TISSUE” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **pisohamate ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -4091,7 +4091,7 @@
   },
   {
     "root": "RŢTH",
-    "refers": "\"OTHER HAND/WRIST TISSUE\" III",
+    "refers": "“OTHER HAND/WRIST TISSUE” III",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **carpal tunnel** [both the material/physical aspect and the functional aspect thereof]",
@@ -4141,7 +4141,7 @@
   },
   {
     "root": "PŢTL",
-    "refers": "\"ELBOW LIGAMENT\" I",
+    "refers": "“ELBOW LIGAMENT” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **annular ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -4166,7 +4166,7 @@
   },
   {
     "root": "PŢTR",
-    "refers": "\"ELBOW LIGAMENT\" II",
+    "refers": "“ELBOW LIGAMENT” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **radial collateral ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -4191,7 +4191,7 @@
   },
   {
     "root": "PŢTŘ",
-    "refers": "\"SHOULDER LIGAMENT\" I",
+    "refers": "“SHOULDER LIGAMENT” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **anterior sternoclavicular ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -4216,7 +4216,7 @@
   },
   {
     "root": "PŢTĻ",
-    "refers": "\"SHOULDER LIGAMENT\" II",
+    "refers": "“SHOULDER LIGAMENT” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **costoclavicular ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -4241,7 +4241,7 @@
   },
   {
     "root": "PŢTÇ",
-    "refers": "\"SHOULDER LIGAMENT\" III",
+    "refers": "“SHOULDER LIGAMENT” III",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **superior transverse scapular ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -4266,7 +4266,7 @@
   },
   {
     "root": "PŢTH",
-    "refers": "\"SHOULDER LIGAMENT\" IV",
+    "refers": "“SHOULDER LIGAMENT” IV",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **superior glenohumeral ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -4291,7 +4291,7 @@
   },
   {
     "root": "PŢTHW",
-    "refers": "\"SHOULDER LIGAMENT\" V",
+    "refers": "“SHOULDER LIGAMENT” V",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **coracohumeral ligament** [both the material/physical aspect and the functional aspect thereof]",
@@ -4316,7 +4316,7 @@
   },
   {
     "root": "PÇL",
-    "refers": "\"OTHER BODILY TISSUE\" I",
+    "refers": "“OTHER BODILY TISSUE” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **tendinous intersection / tendinous inscription** [both the material/physical aspect and the functional aspect thereof]",
@@ -4341,7 +4341,7 @@
   },
   {
     "root": "PÇR",
-    "refers": "\"OTHER BODILY TISSUE\" II",
+    "refers": "“OTHER BODILY TISSUE” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **xiphoid process / ensiform process / xiphisternum / metasternum** [both the material/physical aspect and the functional aspect thereof]",

--- a/lexicon/7.2.1.json
+++ b/lexicon/7.2.1.json
@@ -112,10 +112,10 @@
         "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **leg as ambulatory appendage of animal or ambulatory entity** belongs or is from"
       },
       {
-        "BSC": "(to be) a particular bodily part/organ/tissue identified as **leg as functional \"tool\"/manipulator (e.g., with which to kick, push, press, apply force, etc.)** [both the material/physical aspect and the functional aspect thereof]",
-        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **leg as functional \"tool\"/manipulator (e.g., with which to kick, push, press, apply force, etc.)**",
-        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **leg as functional \"tool\"/manipulator (e.g., with which to kick, push, press, apply force, etc.)**",
-        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **leg as functional \"tool\"/manipulator (e.g., with which to kick, push, press, apply force, etc.)** belongs or is from"
+        "BSC": "(to be) a particular bodily part/organ/tissue identified as **leg as functional “tool”/manipulator (e.g., with which to kick, push, press, apply force, etc.)** [both the material/physical aspect and the functional aspect thereof]",
+        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **leg as functional “tool”/manipulator (e.g., with which to kick, push, press, apply force, etc.)**",
+        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **leg as functional “tool”/manipulator (e.g., with which to kick, push, press, apply force, etc.)**",
+        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **leg as functional “tool”/manipulator (e.g., with which to kick, push, press, apply force, etc.)** belongs or is from"
       }
     ]
   },
@@ -136,10 +136,10 @@
         "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **arm as appendage of animal (or anthropomorphic entity) for holding, carrying, lifting** belongs or is from"
       },
       {
-        "BSC": "(to be) a particular bodily part/organ/tissue identified as **arm as functional \"tool\"/manipulator by which to reach, hit, push, press, apply force, protect oneself, etc.** [both the material/physical aspect and the functional aspect thereof]",
-        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **arm as functional \"tool\"/manipulator by which to reach, hit, push, press, apply force, protect oneself, etc.**",
-        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **arm as functional \"tool\"/manipulator by which to reach, hit, push, press, apply force, protect oneself, etc.**",
-        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **arm as functional \"tool\"/manipulator by which to reach, hit, push, press, apply force, protect oneself, etc.** belongs or is from"
+        "BSC": "(to be) a particular bodily part/organ/tissue identified as **arm as functional “tool”/manipulator by which to reach, hit, push, press, apply force, protect oneself, etc.** [both the material/physical aspect and the functional aspect thereof]",
+        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **arm as functional “tool”/manipulator by which to reach, hit, push, press, apply force, protect oneself, etc.**",
+        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **arm as functional “tool”/manipulator by which to reach, hit, push, press, apply force, protect oneself, etc.**",
+        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **arm as functional “tool”/manipulator by which to reach, hit, push, press, apply force, protect oneself, etc.** belongs or is from"
       }
     ]
   },
@@ -196,10 +196,10 @@
     "refers": "HEAD",
     "stems": [
       {
-        "BSC": "(to be) a particular bodily part/organ/tissue identified as **head as a living being's primary \"interface\" or \"access point\" for communication, ingestion, non-tactile sensory input, etc.** [both the material/physical aspect and the functional aspect thereof]",
-        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **head as a living being's primary \"interface\" or \"access point\" for communication, ingestion, non-tactile sensory input, etc.**",
-        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **head as a living being's primary \"interface\" or \"access point\" for communication, ingestion, non-tactile sensory input, etc.**",
-        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **head as a living being's primary \"interface\" or \"access point\" for communication, ingestion, non-tactile sensory input, etc.** belongs or is from"
+        "BSC": "(to be) a particular bodily part/organ/tissue identified as **head as a living being's primary “interface” or “access point” for communication, ingestion, non-tactile sensory input, etc.** [both the material/physical aspect and the functional aspect thereof]",
+        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **head as a living being's primary “interface” or “access point” for communication, ingestion, non-tactile sensory input, etc.**",
+        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **head as a living being's primary “interface” or “access point” for communication, ingestion, non-tactile sensory input, etc.**",
+        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **head as a living being's primary “interface” or “access point” for communication, ingestion, non-tactile sensory input, etc.** belongs or is from"
       },
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **head as seat of one's consciousness/personality/identity/mind/brain** [both the material/physical aspect and the functional aspect thereof]",
@@ -208,10 +208,10 @@
         "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **head as seat of one's consciousness/personality/identity/mind/brain** belongs or is from"
       },
       {
-        "BSC": "(to be) a particular bodily part/organ/tissue identified as **head as \"top\" or \"forward\" extension of bodily form** [both the material/physical aspect and the functional aspect thereof]",
-        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **head as \"top\" or \"forward\" extension of bodily form**",
-        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **head as \"top\" or \"forward\" extension of bodily form**",
-        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **head as \"top\" or \"forward\" extension of bodily form** belongs or is from"
+        "BSC": "(to be) a particular bodily part/organ/tissue identified as **head as “top” or “forward” extension of bodily form** [both the material/physical aspect and the functional aspect thereof]",
+        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **head as “top” or “forward” extension of bodily form**",
+        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **head as “top” or “forward” extension of bodily form**",
+        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **head as “top” or “forward” extension of bodily form** belongs or is from"
       }
     ]
   },
@@ -232,10 +232,10 @@
         "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **hand as holder, grasper, striker** belongs or is from"
       },
       {
-        "BSC": "(to be) a particular bodily part/organ/tissue identified as **hand as primary tactile-sensory interface, \"feeler\", toucher** [both the material/physical aspect and the functional aspect thereof]",
-        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **hand as primary tactile-sensory interface, \"feeler\", toucher**",
-        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **hand as primary tactile-sensory interface, \"feeler\", toucher**",
-        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **hand as primary tactile-sensory interface, \"feeler\", toucher** belongs or is from"
+        "BSC": "(to be) a particular bodily part/organ/tissue identified as **hand as primary tactile-sensory interface, “feeler”, toucher** [both the material/physical aspect and the functional aspect thereof]",
+        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **hand as primary tactile-sensory interface, “feeler”, toucher**",
+        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **hand as primary tactile-sensory interface, “feeler”, toucher**",
+        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **hand as primary tactile-sensory interface, “feeler”, toucher** belongs or is from"
       }
     ]
   },
@@ -305,10 +305,10 @@
         "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **foot/paw as ambulatory appendage** belongs or is from"
       },
       {
-        "BSC": "(to be) a particular bodily part/organ/tissue identified as **foot/paw as functional \"tool\"/manipulator (e.g., with which to kick, push, press, apply force, etc.)** [both the material/physical aspect and the functional aspect thereof]",
-        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **foot/paw as functional \"tool\"/manipulator (e.g., with which to kick, push, press, apply force, etc.)**",
-        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **foot/paw as functional \"tool\"/manipulator (e.g., with which to kick, push, press, apply force, etc.)**",
-        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **foot/paw as functional \"tool\"/manipulator (e.g., with which to kick, push, press, apply force, etc.)** belongs or is from"
+        "BSC": "(to be) a particular bodily part/organ/tissue identified as **foot/paw as functional “tool”/manipulator (e.g., with which to kick, push, press, apply force, etc.)** [both the material/physical aspect and the functional aspect thereof]",
+        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **foot/paw as functional “tool”/manipulator (e.g., with which to kick, push, press, apply force, etc.)**",
+        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **foot/paw as functional “tool”/manipulator (e.g., with which to kick, push, press, apply force, etc.)**",
+        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **foot/paw as functional “tool”/manipulator (e.g., with which to kick, push, press, apply force, etc.)** belongs or is from"
       }
     ]
   },
@@ -317,22 +317,22 @@
     "refers": "PART OF HAND OR FOOT",
     "stems": [
       {
-        "BSC": "(to be) a particular bodily part/organ/tissue identified as **quasi-flat ventral mid-part of appendage (concatenate \"hand\" or \"foot\" to specify whether palm or underside of foot)** [both the material/physical aspect and the functional aspect thereof]",
-        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **quasi-flat ventral mid-part of appendage (concatenate \"hand\" or \"foot\" to specify whether palm or underside of foot)**",
-        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **quasi-flat ventral mid-part of appendage (concatenate \"hand\" or \"foot\" to specify whether palm or underside of foot)**",
-        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **quasi-flat ventral mid-part of appendage (concatenate \"hand\" or \"foot\" to specify whether palm or underside of foot)** belongs or is from"
+        "BSC": "(to be) a particular bodily part/organ/tissue identified as **quasi-flat ventral mid-part of appendage (concatenate “hand” or “foot” to specify whether palm or underside of foot)** [both the material/physical aspect and the functional aspect thereof]",
+        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **quasi-flat ventral mid-part of appendage (concatenate “hand” or “foot” to specify whether palm or underside of foot)**",
+        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **quasi-flat ventral mid-part of appendage (concatenate “hand” or “foot” to specify whether palm or underside of foot)**",
+        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **quasi-flat ventral mid-part of appendage (concatenate “hand” or “foot” to specify whether palm or underside of foot)** belongs or is from"
       },
       {
-        "BSC": "(to be) a particular bodily part/organ/tissue identified as **ball of the foot or upper palmar ridge of the hand (concatenate \"hand\" or \"foot\" to specify which)** [both the material/physical aspect and the functional aspect thereof]",
-        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **ball of the foot or upper palmar ridge of the hand (concatenate \"hand\" or \"foot\" to specify which)**",
-        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **ball of the foot or upper palmar ridge of the hand (concatenate \"hand\" or \"foot\" to specify which)**",
-        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **ball of the foot or upper palmar ridge of the hand (concatenate \"hand\" or \"foot\" to specify which)** belongs or is from"
+        "BSC": "(to be) a particular bodily part/organ/tissue identified as **ball of the foot or upper palmar ridge of the hand (concatenate “hand” or “foot” to specify which)** [both the material/physical aspect and the functional aspect thereof]",
+        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **ball of the foot or upper palmar ridge of the hand (concatenate “hand” or “foot” to specify which)**",
+        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **ball of the foot or upper palmar ridge of the hand (concatenate “hand” or “foot” to specify which)**",
+        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **ball of the foot or upper palmar ridge of the hand (concatenate “hand” or “foot” to specify which)** belongs or is from"
       },
       {
-        "BSC": "(to be) a particular bodily part/organ/tissue identified as **butt of the hand or foot (concatenate \"hand\" or \"foot\" to specify whether butt of the palm or heel)** [both the material/physical aspect and the functional aspect thereof]",
-        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **butt of the hand or foot (concatenate \"hand\" or \"foot\" to specify whether butt of the palm or heel)**",
-        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **butt of the hand or foot (concatenate \"hand\" or \"foot\" to specify whether butt of the palm or heel)**",
-        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **butt of the hand or foot (concatenate \"hand\" or \"foot\" to specify whether butt of the palm or heel)** belongs or is from"
+        "BSC": "(to be) a particular bodily part/organ/tissue identified as **butt of the hand or foot (concatenate “hand” or “foot” to specify whether butt of the palm or heel)** [both the material/physical aspect and the functional aspect thereof]",
+        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **butt of the hand or foot (concatenate “hand” or “foot” to specify whether butt of the palm or heel)**",
+        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **butt of the hand or foot (concatenate “hand” or “foot” to specify whether butt of the palm or heel)**",
+        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **butt of the hand or foot (concatenate “hand” or “foot” to specify whether butt of the palm or heel)** belongs or is from"
       }
     ]
   },
@@ -803,10 +803,10 @@
         "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **chest, pectoral area** belongs or is from"
       },
       {
-        "BSC": "(to be) a particular bodily part/organ/tissue identified as **abdomen, midriff, waist, \"stomach\"/ \"belly\" / \"tummy\" area** [both the material/physical aspect and the functional aspect thereof]",
-        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **abdomen, midriff, waist, \"stomach\"/ \"belly\" / \"tummy\" area**",
-        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **abdomen, midriff, waist, \"stomach\"/ \"belly\" / \"tummy\" area**",
-        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **abdomen, midriff, waist, \"stomach\"/ \"belly\" / \"tummy\" area** belongs or is from"
+        "BSC": "(to be) a particular bodily part/organ/tissue identified as **abdomen, midriff, waist, “stomach”/ “belly” / “tummy” area** [both the material/physical aspect and the functional aspect thereof]",
+        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **abdomen, midriff, waist, “stomach”/ “belly” / “tummy” area**",
+        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **abdomen, midriff, waist, “stomach”/ “belly” / “tummy” area**",
+        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **abdomen, midriff, waist, “stomach”/ “belly” / “tummy” area** belongs or is from"
       },
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **trunk, thorax** [both the material/physical aspect and the functional aspect thereof]",
@@ -917,16 +917,16 @@
     "refers": "SPECIALTY HAIR-LIKE TISSUE",
     "stems": [
       {
-        "BSC": "(to be) a particular bodily part/organ/tissue identified as **an eyelash hair [use appropriate configuration for \"eyelashes\"]** [both the material/physical aspect and the functional aspect thereof]",
-        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **an eyelash hair [use appropriate configuration for \"eyelashes\"]**",
-        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **an eyelash hair [use appropriate configuration for \"eyelashes\"]**",
-        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **an eyelash hair [use appropriate configuration for \"eyelashes\"]** belongs or is from"
+        "BSC": "(to be) a particular bodily part/organ/tissue identified as **an eyelash hair [use appropriate configuration for “eyelashes”]** [both the material/physical aspect and the functional aspect thereof]",
+        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **an eyelash hair [use appropriate configuration for “eyelashes”]**",
+        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **an eyelash hair [use appropriate configuration for “eyelashes”]**",
+        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **an eyelash hair [use appropriate configuration for “eyelashes”]** belongs or is from"
       },
       {
-        "BSC": "(to be) a particular bodily part/organ/tissue identified as **an eyebrow hair [use appropriate configuration for \"eyebrow\"]** [both the material/physical aspect and the functional aspect thereof]",
-        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **an eyebrow hair [use appropriate configuration for \"eyebrow\"]**",
-        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **an eyebrow hair [use appropriate configuration for \"eyebrow\"]**",
-        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **an eyebrow hair [use appropriate configuration for \"eyebrow\"]** belongs or is from"
+        "BSC": "(to be) a particular bodily part/organ/tissue identified as **an eyebrow hair [use appropriate configuration for “eyebrow”]** [both the material/physical aspect and the functional aspect thereof]",
+        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **an eyebrow hair [use appropriate configuration for “eyebrow”]**",
+        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **an eyebrow hair [use appropriate configuration for “eyebrow”]**",
+        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **an eyebrow hair [use appropriate configuration for “eyebrow”]** belongs or is from"
       },
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **a whisker/vibrissa** [both the material/physical aspect and the functional aspect thereof]",
@@ -1193,10 +1193,10 @@
         "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **bicuspid** belongs or is from"
       },
       {
-        "BSC": "(to be) a particular bodily part/organ/tissue identified as **molar [concatenate this stem with -PFW- to render \"premolar\"]** [both the material/physical aspect and the functional aspect thereof]",
-        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **molar [concatenate this stem with -PFW- to render \"premolar\"]**",
-        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **molar [concatenate this stem with -PFW- to render \"premolar\"]**",
-        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **molar [concatenate this stem with -PFW- to render \"premolar\"]** belongs or is from"
+        "BSC": "(to be) a particular bodily part/organ/tissue identified as **molar [concatenate this stem with -PFW- to render “premolar”]** [both the material/physical aspect and the functional aspect thereof]",
+        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **molar [concatenate this stem with -PFW- to render “premolar”]**",
+        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **molar [concatenate this stem with -PFW- to render “premolar”]**",
+        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **molar [concatenate this stem with -PFW- to render “premolar”]** belongs or is from"
       }
     ]
   },
@@ -1301,10 +1301,10 @@
     "refers": "PARTS OF A BODILY JOINT",
     "stems": [
       {
-        "BSC": "(to be) a particular bodily part/organ/tissue identified as **(to be) the superior/dorsal side of a bodily joint [i.e., the \"hard/bony\" side of a bodily joint]*** [both the material/physical aspect and the functional aspect thereof]",
-        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **(to be) the superior/dorsal side of a bodily joint [i.e., the \"hard/bony\" side of a bodily joint]***",
-        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **(to be) the superior/dorsal side of a bodily joint [i.e., the \"hard/bony\" side of a bodily joint]***",
-        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **(to be) the superior/dorsal side of a bodily joint [i.e., the \"hard/bony\" side of a bodily joint]*** belongs or is from"
+        "BSC": "(to be) a particular bodily part/organ/tissue identified as **(to be) the superior/dorsal side of a bodily joint [i.e., the “hard/bony” side of a bodily joint]*** [both the material/physical aspect and the functional aspect thereof]",
+        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **(to be) the superior/dorsal side of a bodily joint [i.e., the “hard/bony” side of a bodily joint]***",
+        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **(to be) the superior/dorsal side of a bodily joint [i.e., the “hard/bony” side of a bodily joint]***",
+        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **(to be) the superior/dorsal side of a bodily joint [i.e., the “hard/bony” side of a bodily joint]*** belongs or is from"
       },
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **(to be) the inferior/ventral side of a bodily joint [i.e., the soft, concave side of a bodily joint]*** [both the material/physical aspect and the functional aspect thereof]",
@@ -1313,13 +1313,13 @@
         "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **(to be) the inferior/ventral side of a bodily joint [i.e., the soft, concave side of a bodily joint]*** belongs or is from"
       },
       {
-        "BSC": "(to be) a particular bodily part/organ/tissue identified as **(to be) the internal \"swivel\" mechanism of a bodily joint (i.e., the internal anatomy of a joint which allows an appendage to bend/twist)*** [both the material/physical aspect and the functional aspect thereof]",
-        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **(to be) the internal \"swivel\" mechanism of a bodily joint (i.e., the internal anatomy of a joint which allows an appendage to bend/twist)***",
-        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **(to be) the internal \"swivel\" mechanism of a bodily joint (i.e., the internal anatomy of a joint which allows an appendage to bend/twist)***",
-        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **(to be) the internal \"swivel\" mechanism of a bodily joint (i.e., the internal anatomy of a joint which allows an appendage to bend/twist)*** belongs or is from"
+        "BSC": "(to be) a particular bodily part/organ/tissue identified as **(to be) the internal “swivel” mechanism of a bodily joint (i.e., the internal anatomy of a joint which allows an appendage to bend/twist)*** [both the material/physical aspect and the functional aspect thereof]",
+        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **(to be) the internal “swivel” mechanism of a bodily joint (i.e., the internal anatomy of a joint which allows an appendage to bend/twist)***",
+        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **(to be) the internal “swivel” mechanism of a bodily joint (i.e., the internal anatomy of a joint which allows an appendage to bend/twist)***",
+        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **(to be) the internal “swivel” mechanism of a bodily joint (i.e., the internal anatomy of a joint which allows an appendage to bend/twist)*** belongs or is from"
       }
     ],
-    "notes": "*concatenate the stem of a specific limb or digit to specify \"elbow\", \"knee\", \"knuckle (of finger)\", 'knuckle (of toe), \"shoulder\", etc."
+    "notes": "*concatenate the stem of a specific limb or digit to specify “elbow”, “knee”, “knuckle (of finger)”, 'knuckle (of toe), “shoulder”, etc."
   },
   {
     "root": "LDN",
@@ -1563,13 +1563,13 @@
   },
   {
     "root": "MFP",
-    "refers": "\"LIP\" *",
+    "refers": "“LIP” *",
     "stems": [
       {
-        "BSC": "(to be) a particular bodily part/organ/tissue identified as **lip as aperture or \"seal\" to one's mouth** [both the material/physical aspect and the functional aspect thereof]",
-        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **lip as aperture or \"seal\" to one's mouth**",
-        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **lip as aperture or \"seal\" to one's mouth**",
-        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **lip as aperture or \"seal\" to one's mouth** belongs or is from"
+        "BSC": "(to be) a particular bodily part/organ/tissue identified as **lip as aperture or “seal” to one's mouth** [both the material/physical aspect and the functional aspect thereof]",
+        "CTE": "(to be) the function of a particular bodily part/organ/tissue identified as **lip as aperture or “seal” to one's mouth**",
+        "CSV": "(to be) the physical/material make-up of a particular bodily part/organ/tissue identified as **lip as aperture or “seal” to one's mouth**",
+        "OBJ": "(to be) the body to whom the particular bodily part/organ/tissue identified as **lip as aperture or “seal” to one's mouth** belongs or is from"
       },
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **lip as manipulative organ for the production of spoken language** [both the material/physical aspect and the functional aspect thereof]",
@@ -1612,7 +1612,7 @@
   },
   {
     "root": "LPSL",
-    "refers": "\"MAJOR ARTERY\" I",
+    "refers": "“MAJOR ARTERY” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **aorta** [both the material/physical aspect and the functional aspect thereof]",
@@ -1636,7 +1636,7 @@
   },
   {
     "root": "LPÇL",
-    "refers": "\"MAJOR ARTERY\" II",
+    "refers": "“MAJOR ARTERY” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **brachiocephalic artery** [both the material/physical aspect and the functional aspect thereof]",
@@ -1660,7 +1660,7 @@
   },
   {
     "root": "LPFL",
-    "refers": "\"MAJOR ARTERY\" III",
+    "refers": "“MAJOR ARTERY” III",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **iliac artery** [both the material/physical aspect and the functional aspect thereof]",
@@ -1684,7 +1684,7 @@
   },
   {
     "root": "LBZL",
-    "refers": "\"MAJOR VEIN\" I",
+    "refers": "“MAJOR VEIN” I",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **vena cava** [both the material/physical aspect and the functional aspect thereof]",
@@ -1708,7 +1708,7 @@
   },
   {
     "root": "LBŽL",
-    "refers": "\"MAJOR VEIN\" II",
+    "refers": "“MAJOR VEIN” II",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **brachiocephalic vein** [both the material/physical aspect and the functional aspect thereof]",
@@ -1732,7 +1732,7 @@
   },
   {
     "root": "LẒL",
-    "refers": "\"MAJOR VEIN\" III",
+    "refers": "“MAJOR VEIN” III",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **subclavian vein** [both the material/physical aspect and the functional aspect thereof]",
@@ -1756,7 +1756,7 @@
   },
   {
     "root": "LJL",
-    "refers": "\"MAJOR VEIN\" IV",
+    "refers": "“MAJOR VEIN” IV",
     "stems": [
       {
         "BSC": "(to be) a particular bodily part/organ/tissue identified as **iliac vein** [both the material/physical aspect and the functional aspect thereof]",

--- a/lexicon/7.2.3.json
+++ b/lexicon/7.2.3.json
@@ -187,7 +187,7 @@
     "stems": [
       "syncope (fainting)",
       "altitude sickness",
-      "nitrogen narcosis (\"the bends\")"
+      "nitrogen narcosis (“the bends”)"
     ],
     "see": "ÇK"
   },

--- a/lexicon/7.2.json
+++ b/lexicon/7.2.json
@@ -82,7 +82,7 @@
         "CSV": "(to be) a state/act of doing something that demonstrates one is awake/conscious",
         "OBJ": "(to be) the level of awareness of oneself and one's surroundings one has while awake"
       },
-      "(to be) a state/process of waking (up); to transition from sleep to wakefulness, to \"come about\", to be waking up, to be regaining consciousness [CPT version = to regain consciousness, to come fully awake]",
+      "(to be) a state/process of waking (up); to transition from sleep to wakefulness, to “come about”, to be waking up, to be regaining consciousness [CPT version = to regain consciousness, to come fully awake]",
       "(to be) a state of dozing or being half-awake; to doze, to be half-asleep, half- awake, to be in a state of half-sleep"
     ]
   },
@@ -110,7 +110,7 @@
         "CSV": "(to be) a degree of brute bodily strength",
         "OBJ": "(to be) an entity/party impacted/affected by one's degree of brute bodily strength"
       },
-      "(to be/manifest a) degree of bodily energy/vigor/vitality; \"feel weak/strong\"",
+      "(to be/manifest a) degree of bodily energy/vigor/vitality; “feel weak/strong”",
       "(to be/manifest a) degree of stamina"
     ],
     "notes": "Affix: STR (use SUF/EXN/EXD, etc.)"
@@ -127,7 +127,7 @@
         "OBJ": "(to be) an entity/party impacted/affected by one's degree of applied physical force"
       },
       "(to be/manifest a) degree of energy",
-      "(to be/manifest a) degree of potency, \"might\" ( = potential strength/power to cause or accomplish something)"
+      "(to be/manifest a) degree of potency, “might” ( = potential strength/power to cause or accomplish something)"
     ],
     "notes": "Affix: FRC (use SUF/EXN/EXD, etc.)"
   },
@@ -148,15 +148,15 @@
   },
   {
     "root": "JMW",
-    "refers": "HAND AS FLAT RIGID \"BLADE\"",
+    "refers": "HAND AS FLAT RIGID “BLADE”",
     "stems": [
       {
-        "BSC": "(to be) a hand as flat rigid \"blade\" for use of outside \"edge\" of rigidly-held hand (as in a karate chop)",
+        "BSC": "(to be) a hand as flat rigid “blade” for use of outside “edge” of rigidly-held hand (as in a karate chop)",
         "CTE": "(to be) the physical process of chopping with one's hand",
         "CSV": "(to be) a closed fist used in chopping with one's hand",
         "OBJ": "(to be) the blow/impact delivered from chopping with one's hand "
       },
-      "(to be) a hand as flat rigid \"blade\" for use of fingers used \"head-on\" for pressing/jabbing/poking",
+      "(to be) a hand as flat rigid “blade” for use of fingers used “head-on” for pressing/jabbing/poking",
       "(to be) a hand held flat and rigid for use in covering something or stopping something from escaping (e.g., from a hole or tear)"
     ]
   },

--- a/lexicon/7.3.1.1.json
+++ b/lexicon/7.3.1.1.json
@@ -706,16 +706,16 @@
         "OBJ": "(to be) an activity engaged in by an animal identified as **dzo/yakow (cow/bull + yak)**; what an animal of such kind is doing; to act (as a particular animal species of such kind does)"
       },
       {
-        "BSC": "(to be) an animal identified as **\"beefalo\"/ \"zubron\" (cow + bison)**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
-        "CTE": "(to be) that which gives a particular animal identified as **\"beefalo\"/ \"zubron\" (cow + bison)** its individual identity; the living essence or mental identity of an animal of such kind",
-        "CSV": "(to be) the physical body of an animal identified as **\"beefalo\"/ \"zubron\" (cow + bison)**; the corporeal aspect of an animal of such kind",
-        "OBJ": "(to be) an activity engaged in by an animal identified as **\"beefalo\"/ \"zubron\" (cow + bison)**; what an animal of such kind is doing; to act (as a particular animal species of such kind does)"
+        "BSC": "(to be) an animal identified as **“beefalo”/ “zubron” (cow + bison)**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
+        "CTE": "(to be) that which gives a particular animal identified as **“beefalo”/ “zubron” (cow + bison)** its individual identity; the living essence or mental identity of an animal of such kind",
+        "CSV": "(to be) the physical body of an animal identified as **“beefalo”/ “zubron” (cow + bison)**; the corporeal aspect of an animal of such kind",
+        "OBJ": "(to be) an activity engaged in by an animal identified as **“beefalo”/ “zubron” (cow + bison)**; what an animal of such kind is doing; to act (as a particular animal species of such kind does)"
       },
       {
-        "BSC": "(to be) an animal identified as **\"yakalo\" (bison + yak)**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
-        "CTE": "(to be) that which gives a particular animal identified as **\"yakalo\" (bison + yak)** its individual identity; the living essence or mental identity of an animal of such kind",
-        "CSV": "(to be) the physical body of an animal identified as **\"yakalo\" (bison + yak)**; the corporeal aspect of an animal of such kind",
-        "OBJ": "(to be) an activity engaged in by an animal identified as **\"yakalo\" (bison + yak)**; what an animal of such kind is doing; to act (as a particular animal species of such kind does)"
+        "BSC": "(to be) an animal identified as **“yakalo” (bison + yak)**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
+        "CTE": "(to be) that which gives a particular animal identified as **“yakalo” (bison + yak)** its individual identity; the living essence or mental identity of an animal of such kind",
+        "CSV": "(to be) the physical body of an animal identified as **“yakalo” (bison + yak)**; the corporeal aspect of an animal of such kind",
+        "OBJ": "(to be) an activity engaged in by an animal identified as **“yakalo” (bison + yak)**; what an animal of such kind is doing; to act (as a particular animal species of such kind does)"
       }
     ]
   },
@@ -1576,10 +1576,10 @@
         "OBJ": "(to be) an activity engaged in by an animal identified as **hinny**; what an animal of such kind is doing; to act (as a particular animal species of such kind does)"
       },
       {
-        "BSC": "(to be) an animal identified as **\"zebroid\" (including \"zorse\", \"zeedonk\", \"zony\")**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
-        "CTE": "(to be) that which gives a particular animal identified as **\"zebroid\" (including \"zorse\", \"zeedonk\", \"zony\")** its individual identity; the living essence or mental identity of an animal of such kind",
-        "CSV": "(to be) the physical body of an animal identified as **\"zebroid\" (including \"zorse\", \"zeedonk\", \"zony\")**; the corporeal aspect of an animal of such kind",
-        "OBJ": "(to be) an activity engaged in by an animal identified as **\"zebroid\" (including \"zorse\", \"zeedonk\", \"zony\")**; what an animal of such kind is doing; to act (as a particular animal species of such kind does)"
+        "BSC": "(to be) an animal identified as **“zebroid” (including “zorse”, “zeedonk”, “zony”)**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
+        "CTE": "(to be) that which gives a particular animal identified as **“zebroid” (including “zorse”, “zeedonk”, “zony”)** its individual identity; the living essence or mental identity of an animal of such kind",
+        "CSV": "(to be) the physical body of an animal identified as **“zebroid” (including “zorse”, “zeedonk”, “zony”)**; the corporeal aspect of an animal of such kind",
+        "OBJ": "(to be) an activity engaged in by an animal identified as **“zebroid” (including “zorse”, “zeedonk”, “zony”)**; what an animal of such kind is doing; to act (as a particular animal species of such kind does)"
       }
     ]
   },
@@ -2809,7 +2809,7 @@
   },
   {
     "root": "VXL",
-    "refers": "PHOCID (\"EARLESS\" / \"TRUE\") SEAL",
+    "refers": "PHOCID (“EARLESS” / “TRUE”) SEAL",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Arctic/Northern seals: genera Phoca, Pusa, Halichoerus, Histriophoca, Pagophilus, Erignathus, Cystophora) seal**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2833,7 +2833,7 @@
   },
   {
     "root": "VXR",
-    "refers": "OTARIID (\"EARED\") SEAL",
+    "refers": "OTARIID (“EARED”) SEAL",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Arctocephalus, Callorhinus) fur seal**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",

--- a/lexicon/7.3.1.2.json
+++ b/lexicon/7.3.1.2.json
@@ -433,7 +433,7 @@
   },
   {
     "root": "ZZK",
-    "refers": "\"ELAPID SNAKE\" I",
+    "refers": "“ELAPID SNAKE” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Naja, Pseudohaje, Walterinnesia, Boulengerina, Aspidelaps) cobra**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -457,7 +457,7 @@
   },
   {
     "root": "ZZKW",
-    "refers": "\"ELAPID SNAKE\" II",
+    "refers": "“ELAPID SNAKE” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Dendroaspis) mamba**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -481,7 +481,7 @@
   },
   {
     "root": "ZZKY",
-    "refers": "\"ELAPID SNAKE\" III",
+    "refers": "“ELAPID SNAKE” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Calliophis, Hemibungaris, Sinomicrurus) Old World coral snake**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -505,7 +505,7 @@
   },
   {
     "root": "ZZKL",
-    "refers": "\"ELAPID SNAKE\" IV",
+    "refers": "“ELAPID SNAKE” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Laticauda) sea krait**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -529,7 +529,7 @@
   },
   {
     "root": "ZZKR",
-    "refers": "\"ELAPID SNAKE\" V",
+    "refers": "“ELAPID SNAKE” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Ephalophis, Hydrelaps) mudsnake**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -553,7 +553,7 @@
   },
   {
     "root": "ZZKŘ",
-    "refers": "\"ELAPID SNAKE\" VI",
+    "refers": "“ELAPID SNAKE” VI",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Oxyuranus) taipan**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -577,7 +577,7 @@
   },
   {
     "root": "ZZKF",
-    "refers": "\"ELAPID SNAKE\" VII",
+    "refers": "“ELAPID SNAKE” VII",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Acanthophis) death adder**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -601,7 +601,7 @@
   },
   {
     "root": "ZZKŢ",
-    "refers": "\"ELAPID SNAKE\" VIII",
+    "refers": "“ELAPID SNAKE” VIII",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Cacophis) rainforest crowned snake**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -625,7 +625,7 @@
   },
   {
     "root": "ZZKÇ",
-    "refers": "\"ELAPID SNAKE\" IX",
+    "refers": "“ELAPID SNAKE” IX",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Echiopsis) bardick**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -649,7 +649,7 @@
   },
   {
     "root": "ZZKS",
-    "refers": "\"ELAPID SNAKE\" X",
+    "refers": "“ELAPID SNAKE” X",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Homoroselaps) harlequin snake**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -673,7 +673,7 @@
   },
   {
     "root": "ZZKŠ",
-    "refers": "\"ELAPID SNAKE\" XI",
+    "refers": "“ELAPID SNAKE” XI",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Hemiaspis, Hoplocephalus, Paroplocephalus, Pseudonaja, Tropidechis, Vermicella) Australian venemous snake (various): swamp snake, broad-headed snake, pale-headed snake, Lake Cronin snake, dugite, brown snake, rough-scaled snake, bandy-bandy / hoop snake**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",

--- a/lexicon/7.3.1.4.json
+++ b/lexicon/7.3.1.4.json
@@ -1,7 +1,7 @@
 [
   {
     "root": "NSD",
-    "refers": "\"PALEOGNATH\" I",
+    "refers": "“PALEOGNATH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Struthionids; genus Struthio) ostrich**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -25,7 +25,7 @@
   },
   {
     "root": "NSDW",
-    "refers": "\"PALEOGNATH\" II",
+    "refers": "“PALEOGNATH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Casuariids; genus Casuarius) cassowary**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -193,7 +193,7 @@
   },
   {
     "root": "NSPL",
-    "refers": "\"PHASIANINE (PHEASANT)\" I",
+    "refers": "“PHASIANINE (PHEASANT)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Phasianus) [common] pheasant**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -217,7 +217,7 @@
   },
   {
     "root": "NSPR",
-    "refers": "\"PHASIANINE (PHEASANT)\" II",
+    "refers": "“PHASIANINE (PHEASANT)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Pavonii; genera Pavo, Afropavo) peafowl (inluding peacock and peahen)**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -241,7 +241,7 @@
   },
   {
     "root": "NSPŘ",
-    "refers": "\"PHASIANINE (PHEASANT)\" III",
+    "refers": "“PHASIANINE (PHEASANT)” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Argusianus) great argus**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -265,7 +265,7 @@
   },
   {
     "root": "NSPF",
-    "refers": "\"PHASIANINE (PHEASANT)\" IV",
+    "refers": "“PHASIANINE (PHEASANT)” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Chrysolophus) ruffed pheasant, golden pheasant**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -289,7 +289,7 @@
   },
   {
     "root": "NSPV",
-    "refers": "\"PHASIANINE (PHEASANT)\" V",
+    "refers": "“PHASIANINE (PHEASANT)” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Lophura) gallopheasant, fireback**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -337,7 +337,7 @@
   },
   {
     "root": "NSG",
-    "refers": "\"DUCK\" I",
+    "refers": "“DUCK” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Anatines; numerous genera) dabbling duck, mallard, teal, shoveler, pintail, widgeon, gadwall, Asian/Madagascar/East African/Pacific duck**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -361,7 +361,7 @@
   },
   {
     "root": "NSGW",
-    "refers": "\"DUCK\" II",
+    "refers": "“DUCK” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Dendrocynines; genera Dendrocygna, Thalassornis) whistling duck, white-backed duck**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -577,7 +577,7 @@
   },
   {
     "root": "NSBR",
-    "refers": "\"RALLID (RAIL)\" I",
+    "refers": "“RALLID (RAIL)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Rallus, Lewinia, Gallirallus, Rallicula, Dryolimnas, Gymnocrex, Hypotaenidia, Pardirallus, Aramides, Himantornis, Megacrex, Coturnicops) rail, weka**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -601,7 +601,7 @@
   },
   {
     "root": "NSBŘ",
-    "refers": "\"RALLID (RAIL)\" II",
+    "refers": "“RALLID (RAIL)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Canirallus) grey-throated rail**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -673,7 +673,7 @@
   },
   {
     "root": "ŇSDV",
-    "refers": "\"CAPRIMULGIFORM (NIGHTJAR / NIGHTHAWK)\" I",
+    "refers": "“CAPRIMULGIFORM (NIGHTJAR / NIGHTHAWK)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Caprimulgines and Eurostopodines; numerous genera) nightjar, poorwill, whip-poor-will, pauraque**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -697,7 +697,7 @@
   },
   {
     "root": "ŇSGV",
-    "refers": "\"CAPRIMULGIFORM (NIGHTJAR / NIGHTHAWK)\" II",
+    "refers": "“CAPRIMULGIFORM (NIGHTJAR / NIGHTHAWK)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Podargids; genera Podgarus, Batrachostomus, Rigidipenna) frogmouth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -769,7 +769,7 @@
   },
   {
     "root": "NŠT",
-    "refers": "\"CHARADRIIFORM\" I",
+    "refers": "“CHARADRIIFORM” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Charadriids; genera Pluvialis, Pluvianus, Charadrius, Thinornis, Phegornis) plover**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -793,7 +793,7 @@
   },
   {
     "root": "NŠTW",
-    "refers": "\"CHARADRIIFORM\" II",
+    "refers": "“CHARADRIIFORM” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Haematopodids; genus Haematopus) oystercatcher**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -889,7 +889,7 @@
   },
   {
     "root": "NŠTL",
-    "refers": "\"SCOLOPACID (SANDPIPER)\" I",
+    "refers": "“SCOLOPACID (SANDPIPER)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Calidris/Eriola/Ereunetes, Bartramia, Actitis, Xenus, Prosobonia ) sandpiper, stint / peep, knot, sanderling, dunlin, ruff, surfbird**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -913,7 +913,7 @@
   },
   {
     "root": "NŠTR",
-    "refers": "\"SCOLOPACID (SANDPIPER)\" II",
+    "refers": "“SCOLOPACID (SANDPIPER)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Arenaria) turnstone**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1201,7 +1201,7 @@
   },
   {
     "root": "NŠKM",
-    "refers": "\"SULIFORM (BOOBY / GANNET / FRIGATEBIRD)\" I",
+    "refers": "“SULIFORM (BOOBY / GANNET / FRIGATEBIRD)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Sulids; genera Sula, Papasula) booby**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1225,7 +1225,7 @@
   },
   {
     "root": "NŠKN",
-    "refers": "\"SULIFORM (CORMORANT / DARTER)\" II",
+    "refers": "“SULIFORM (CORMORANT / DARTER)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Phalacrocoracids; genera Phalacrocorax, Microcarbo) cormorant, shag**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1369,7 +1369,7 @@
   },
   {
     "root": "ŇSDY",
-    "refers": "\"ACCIPITRIID\" I",
+    "refers": "“ACCIPITRIID” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Aquilines; numerous genera) eagle, hawk-eagle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1393,7 +1393,7 @@
   },
   {
     "root": "ŇSDL",
-    "refers": "\"ACCIPITRIID\" II",
+    "refers": "“ACCIPITRIID” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Milvines and Elanines; numerous genera) kite**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1417,7 +1417,7 @@
   },
   {
     "root": "ŇSDR",
-    "refers": "\"ACCIPITRIID\" III",
+    "refers": "“ACCIPITRIID” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Buteonines; numerous genera) hawk, buzzard, buzzard-eagle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1537,7 +1537,7 @@
   },
   {
     "root": "ŇSPW",
-    "refers": "\"PICIFORM\" I",
+    "refers": "“PICIFORM” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Indicatorids; several genera) honeyguide, honeybird**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1561,7 +1561,7 @@
   },
   {
     "root": "ŇSPY",
-    "refers": "\"PICIFORM\" II",
+    "refers": "“PICIFORM” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Galbulids; several genera) jacamar**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1585,7 +1585,7 @@
   },
   {
     "root": "ŇSPL",
-    "refers": "\"CORACIIFORM\" I",
+    "refers": "“CORACIIFORM” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Coraciids; genera Coracias, Eurystomus) roller, dollarbird**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1609,7 +1609,7 @@
   },
   {
     "root": "ŇSPR",
-    "refers": "\"CORACIIFORM\" II",
+    "refers": "“CORACIIFORM” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Alcedinids; numerous genera) kingfisher, kookaburra**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1777,7 +1777,7 @@
   },
   {
     "root": "ŇSGL",
-    "refers": "\"TYRANNIOID BIRD\" I",
+    "refers": "“TYRANNIOID BIRD” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Piprids; numerous genera) manakin, tyrant-manakin, piprites**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1801,7 +1801,7 @@
   },
   {
     "root": "ŇSGR",
-    "refers": "\"TYRANNIOID BIRD\" II",
+    "refers": "“TYRANNIOID BIRD” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Tyrannids; numerous genera) flycatcher, tyrant, tyrannulet, kiskadee**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1825,7 +1825,7 @@
   },
   {
     "root": "ŇSBW",
-    "refers": "\"FORMICAROID BIRD\" I",
+    "refers": "“FORMICAROID BIRD” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Melanopareiids; genus Malanopareia) crescentchest**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1849,7 +1849,7 @@
   },
   {
     "root": "ŇSBY",
-    "refers": "\"FORMICAROID BIRD\" II",
+    "refers": "“FORMICAROID BIRD” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Grallariids; several genera) antpitta**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1873,7 +1873,7 @@
   },
   {
     "root": "ŇSBL",
-    "refers": "\"FURNARIID (NEOTROPICAL OVENBIRD)\" I",
+    "refers": "“FURNARIID (NEOTROPICAL OVENBIRD)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Furnariini; numerous genera) neotropical ovenbird, hornero, reedhaunter, rushbird, streamcreeper, earthcreeper, barbtail, tuftedcheeks**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1897,7 +1897,7 @@
   },
   {
     "root": "ŇSBR",
-    "refers": "\"FURNARIID (NEOTROPICAL OVENBIRD)\" II",
+    "refers": "“FURNARIID (NEOTROPICAL OVENBIRD)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Synallaxini; numerous genera) spintail, treerunner, rayadito, wiretail, tit-spinetail, thornbird, firweood-gatherer, brushrunner, cacholote, false canastero, wren-spinetail, prickletail, plushcrown, graveteiro, softtail, barbtail, reedhaunter**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1993,7 +1993,7 @@
   },
   {
     "root": "ŇSTL",
-    "refers": "\"ACANTHIZID (AUSTRALIAN WARBLER)\" I",
+    "refers": "“ACANTHIZID (AUSTRALIAN WARBLER)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Sericornis, Aethomyias, Neosericornis) scrubwren**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2017,7 +2017,7 @@
   },
   {
     "root": "ŇSTR",
-    "refers": "\"ACANTHIZID (AUSTRALIAN WARBLER)\" II",
+    "refers": "“ACANTHIZID (AUSTRALIAN WARBLER)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Acanthiza) thornbill**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2041,7 +2041,7 @@
   },
   {
     "root": "ŇSTŘ",
-    "refers": "\"ACANTHIZID (AUSTRALIAN WARBLER)\" III",
+    "refers": "“ACANTHIZID (AUSTRALIAN WARBLER)” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Gerygone) gerygone**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2065,7 +2065,7 @@
   },
   {
     "root": "ŇSTÇ",
-    "refers": "\"ACANTHIZID (AUSTRALIAN WARBLER)\" IV",
+    "refers": "“ACANTHIZID (AUSTRALIAN WARBLER)” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Pyncoptilus) pilotbird**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2209,7 +2209,7 @@
   },
   {
     "root": "ŇSKW",
-    "refers": "\"ORIOLOID BIRD\" I",
+    "refers": "“ORIOLOID BIRD” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Pachycephalids; several genera) whistler, strike-thrush**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2233,7 +2233,7 @@
   },
   {
     "root": "ŇSKY",
-    "refers": "\"ORIOLOID BIRD\" II",
+    "refers": "“ORIOLOID BIRD” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Psophodids; genera Psophodes, Androphobus) whipbird, wedgebill**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2257,7 +2257,7 @@
   },
   {
     "root": "ŇSKL",
-    "refers": "\"VIREONID\" I",
+    "refers": "“VIREONID” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Vireo) vireo**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2281,7 +2281,7 @@
   },
   {
     "root": "ŇSKR",
-    "refers": "\"VIREONID\" II",
+    "refers": "“VIREONID” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Cyclarhis) peppershrike**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2329,7 +2329,7 @@
   },
   {
     "root": "ŇSKM",
-    "refers": "\"MALACONOTOID BIRD\" I",
+    "refers": "“MALACONOTOID BIRD” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Machaerirhynchids; genus Machaerirhynchus) boatbill**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2353,7 +2353,7 @@
   },
   {
     "root": "ŇSKN",
-    "refers": "\"MALACONOTOID BIRD\" II",
+    "refers": "“MALACONOTOID BIRD” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Pityriaseids; genus Pityriasis) bristled shrike / bald-headed wood-shrike / Bornean bristlehead**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2401,7 +2401,7 @@
   },
   {
     "root": "ŇSKF",
-    "refers": "\"VANGID\" I",
+    "refers": "“VANGID” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Vanga, Calicalicus, Schetba, Xenopirostris, Falculea, Artamella, Leptopterus, Cyanolanius, Oriolia, Tylas, Hypositta) vanga**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2425,7 +2425,7 @@
   },
   {
     "root": "ŇSKV",
-    "refers": "\"VANGID\" II",
+    "refers": "“VANGID” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Prionops) helmetshrike**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2473,7 +2473,7 @@
   },
   {
     "root": "NSTW",
-    "refers": "\"CORVID\" I",
+    "refers": "“CORVID” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Pica, Cyanopica, Cissa, Urocissa) magpie**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2497,7 +2497,7 @@
   },
   {
     "root": "NSTY",
-    "refers": "\"CORVID\" II",
+    "refers": "“CORVID” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Podoces) ground jay / ground chough**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2521,7 +2521,7 @@
   },
   {
     "root": "NSTL",
-    "refers": "\"CORVID\" III",
+    "refers": "“CORVID” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Cyanocorax, Cyanocitta, Cyanolyca) jay, blue-jay, Steller's jay**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2545,7 +2545,7 @@
   },
   {
     "root": "NSTR",
-    "refers": "\"CORVID\" IV",
+    "refers": "“CORVID” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Aphelocoma, Gymnorhinus) scrub-jay, pinyon jay**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2569,7 +2569,7 @@
   },
   {
     "root": "NSTM",
-    "refers": "\"CORVOID\" I",
+    "refers": "“CORVOID” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Laniids; several genera) shrike**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2593,7 +2593,7 @@
   },
   {
     "root": "NSTN",
-    "refers": "\"CORVOID\" II",
+    "refers": "“CORVOID” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Dicrurids; genus Dicrurus) drongo, balicassiao**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2665,7 +2665,7 @@
   },
   {
     "root": "NSTÇ",
-    "refers": "\"PARADISAEID (BIRD-OF-PARADISE)\" I",
+    "refers": "“PARADISAEID (BIRD-OF-PARADISE)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Paradisaea, Pteridophora, Semioptera, Seleucidis, Cicinnurus, Paradisornis) bird-of-paradise**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2689,7 +2689,7 @@
   },
   {
     "root": "NSTF",
-    "refers": "\"PARADISAEID (BIRD-OF-PARADISE)\" II",
+    "refers": "“PARADISAEID (BIRD-OF-PARADISE)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Manucodia, Phonygammus) manucode**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2713,7 +2713,7 @@
   },
   {
     "root": "NSTV",
-    "refers": "\"PARADISAEID (BIRD-OF-PARADISE)\" III",
+    "refers": "“PARADISAEID (BIRD-OF-PARADISE)” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Lycocorax) paradise-crow**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2737,7 +2737,7 @@
   },
   {
     "root": "MST",
-    "refers": "\"PASSERID\" I",
+    "refers": "“PASSERID” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Melanocharitids; genera Melanocharis, Rhamphocharis) berrypecker**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2761,7 +2761,7 @@
   },
   {
     "root": "MSTW",
-    "refers": "\"PASSERID\" II",
+    "refers": "“PASSERID” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Notiomystids; genus Notiomystis) stitchbird / hihi**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2881,7 +2881,7 @@
   },
   {
     "root": "MSP",
-    "refers": "\"SYLVIOID BIRD\" I",
+    "refers": "“SYLVIOID BIRD” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Alaudids; numerous genera) lark, skylark, sparrow-lark, hoopoe-lark**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2905,7 +2905,7 @@
   },
   {
     "root": "MSPW",
-    "refers": "\"SYLVIOID BIRD\" II",
+    "refers": "“SYLVIOID BIRD” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Pnoepygids; genus Pnoepyga) cupwing / wren-babbler**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2929,7 +2929,7 @@
   },
   {
     "root": "MSPY",
-    "refers": "\"SYLVIOID BIRD\" III",
+    "refers": "“SYLVIOID BIRD” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Donacobiids; genus Donacobius) black-capped donacobius**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2953,7 +2953,7 @@
   },
   {
     "root": "MSPL",
-    "refers": "\"SYLVIOID BIRD\" IV",
+    "refers": "“SYLVIOID BIRD” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Pycnonotids; numerous genera) bulbul, greenbul, bristlebill, brownbul, leaflove**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2977,7 +2977,7 @@
   },
   {
     "root": "MSPR",
-    "refers": "\"SYLVIOID BIRD\" V",
+    "refers": "“SYLVIOID BIRD” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Sylviids; genus Sylvia) [Old World] warbler, blackcap, whitethroat, parisoma**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3001,7 +3001,7 @@
   },
   {
     "root": "MSPŘ",
-    "refers": "\"SYLVIOID BIRD\" VI",
+    "refers": "“SYLVIOID BIRD” VI",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Sylviids; genera Myzornis, Pseudoalcippe, Horizorhinus, Lioptilus, Fulvetta, Chrysomma, Moupinia, Rhopophilus) babbler, thrush-babbler, fulvetta**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3025,7 +3025,7 @@
   },
   {
     "root": "MSPÇ",
-    "refers": "\"SYLVIOID BIRD\" VII",
+    "refers": "“SYLVIOID BIRD” VII",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Timaliids; numerous genera) [Old World] babbler, wren-babbler, scimitar-babbler, tit-babbler, tawny-bellied babbler, chestnut-capped babbler, wedge-billed babbler, dark-fronted babbler**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3049,7 +3049,7 @@
   },
   {
     "root": "MSPŢ",
-    "refers": "\"SYLVIOID BIRD\" VIII",
+    "refers": "“SYLVIOID BIRD” VIII",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Scotocercids; genus Scotocerca) streaked scrub warbler**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3097,7 +3097,7 @@
   },
   {
     "root": "ŇSB",
-    "refers": "\"CISTICOLID (AFRICAN & ASIAN WARBLER)\" I",
+    "refers": "“CISTICOLID (AFRICAN & ASIAN WARBLER)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Cisticola) cisticola**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3121,7 +3121,7 @@
   },
   {
     "root": "ŇSBŘ",
-    "refers": "\"CISTICOLID (AFRICAN & ASIAN WARBLER)\" II",
+    "refers": "“CISTICOLID (AFRICAN & ASIAN WARBLER)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Prinia, Schistolais, Phragmacia) prinia**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3145,7 +3145,7 @@
   },
   {
     "root": "ŇSG",
-    "refers": "\"CISTICOLID (AFRICAN & ASIAN WARBLER)\" III",
+    "refers": "“CISTICOLID (AFRICAN & ASIAN WARBLER)” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Micromacronus) miniature babbler**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3169,7 +3169,7 @@
   },
   {
     "root": "ŇSGŘ",
-    "refers": "\"CISTICOLID (AFRICAN & ASIAN WARBLER)\" IV",
+    "refers": "“CISTICOLID (AFRICAN & ASIAN WARBLER)” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Camaroptera) camaroptera**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3217,7 +3217,7 @@
   },
   {
     "root": "NSKW",
-    "refers": "\"ERITHACINE\" I",
+    "refers": "“ERITHACINE” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Erithacus) European robin / robin redbreast**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3241,7 +3241,7 @@
   },
   {
     "root": "NSKY",
-    "refers": "\"ERITHACINE\" II",
+    "refers": "“ERITHACINE” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Swynnertonia, Pogonocichla, Stiphrornis) forest robin, robin-chat**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3265,7 +3265,7 @@
   },
   {
     "root": "NSKL",
-    "refers": "\"SAXICOLINE\" I",
+    "refers": "“SAXICOLINE” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Luscinia) nightingale, thrust nightingale, redstart, bluethroat**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3289,7 +3289,7 @@
   },
   {
     "root": "NSKR",
-    "refers": "\"SAXICOLINE\" II",
+    "refers": "“SAXICOLINE” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Saxicola, Campicoloides, Pinarochroa, Thamnolaea, Emarginata,Myrmecocichla, Pinarornis, Namibornis) chat, stonechat, cliff chat, moorland chat**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3313,7 +3313,7 @@
   },
   {
     "root": "NSKŘ",
-    "refers": "\"SAXICOLINE\" III",
+    "refers": "“SAXICOLINE” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Calliope) rubythroat, firethroat, blackthroat**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3337,7 +3337,7 @@
   },
   {
     "root": "NSKF",
-    "refers": "\"SAXICOLINE\" IV",
+    "refers": "“SAXICOLINE” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Myophonus) whistling thrush**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3361,7 +3361,7 @@
   },
   {
     "root": "RNSK",
-    "refers": "\"MUSCICAPOID BIRD\" I",
+    "refers": "“MUSCICAPOID BIRD” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Troglodytids; numerous genera) wren**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3385,7 +3385,7 @@
   },
   {
     "root": "RNSKW",
-    "refers": "\"MUSCICAPOID BIRD\" II",
+    "refers": "“MUSCICAPOID BIRD” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Tichodromadids; genus Tichodroma) wallcreeper**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3409,7 +3409,7 @@
   },
   {
     "root": "RNSKY",
-    "refers": "\"MUSCICAPOID BIRD\" III",
+    "refers": "“MUSCICAPOID BIRD” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Elachurids; genus Elachura) spotted elachura / spotted wren-babbler**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3433,7 +3433,7 @@
   },
   {
     "root": "RNSKL",
-    "refers": "\"MUSCICAPOID BIRD\" IV",
+    "refers": "“MUSCICAPOID BIRD” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Bombycillids; genus Bombycilla) waxwing**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3457,7 +3457,7 @@
   },
   {
     "root": "RNSKR",
-    "refers": "\"MUSCICAPOID BIRD\" V",
+    "refers": "“MUSCICAPOID BIRD” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Mimids; numerous genera) mockingbird, catbird, thrasher**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3577,7 +3577,7 @@
   },
   {
     "root": "ŇŠTY",
-    "refers": "\"PASSERIFORM BIRD\" I",
+    "refers": "“PASSERIFORM BIRD” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Promeropids; genus Promerops) sugarbird**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3601,7 +3601,7 @@
   },
   {
     "root": "ŇŠTL",
-    "refers": "\"PASSERIFORM BIRD\" II",
+    "refers": "“PASSERIFORM BIRD” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Nectariniids; numerous genera) sunbird, spiderhunter**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3625,7 +3625,7 @@
   },
   {
     "root": "ŇŠTR",
-    "refers": "\"PASSERIFORM BIRD\" III",
+    "refers": "“PASSERIFORM BIRD” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Chloropseids; genus Chloropsis) leafbird**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3673,7 +3673,7 @@
   },
   {
     "root": "ŇŠTÇ",
-    "refers": "\"ICTERID\" I",
+    "refers": "“ICTERID” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Agelaius, Xanthspar, Agelasticus, Chrysomus, Nesopsar, Xanthocephalus, Dives, Euphagus, Gymnomystax, Amblyramphus, Curaeus, Anumara, Gnorimopsar, Oreopsar) [New World] blackbird**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3697,7 +3697,7 @@
   },
   {
     "root": "ŇŠTF",
-    "refers": "\"ICTERID\" II",
+    "refers": "“ICTERID” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Molothrus, Agelaioides) cowbird, baywing**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3721,7 +3721,7 @@
   },
   {
     "root": "ŇŠTV",
-    "refers": "\"ICTERID\" III",
+    "refers": "“ICTERID” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Psarocolius) oropendola**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3745,7 +3745,7 @@
   },
   {
     "root": "NŠP",
-    "refers": "\"EMBERIZOID BIRD\" I",
+    "refers": "“EMBERIZOID BIRD” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Passerellids; numerous genera) [American] sparrow, towhee, lark bunting, ground sparrow, junco**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3769,7 +3769,7 @@
   },
   {
     "root": "NŠPW",
-    "refers": "\"EMBERIZOID BIRD\" II",
+    "refers": "“EMBERIZOID BIRD” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Phaenicophilids; genera Phaenicophilus, Xenoligea, Microligea) tanager, white-winged warbler, green-tailed warbler**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3793,7 +3793,7 @@
   },
   {
     "root": "NŠPY",
-    "refers": "\"EMBERIZOID BIRD\" III",
+    "refers": "“EMBERIZOID BIRD” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Parulids; numerous genera) [New World] warbler, wood warbler, oven bird, waterthrush, yellowthroat, whitestart, parula, redstart**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3817,7 +3817,7 @@
   },
   {
     "root": "NŠPL",
-    "refers": "\"EMBERIZOID BIRD\" IV",
+    "refers": "“EMBERIZOID BIRD” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Microspingids; genera Mitrospingus, Orthogonys, Lamprospiza) micropspingid tanager**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3841,7 +3841,7 @@
   },
   {
     "root": "NŠPR",
-    "refers": "\"THRAUPID (TANAGER)\" I",
+    "refers": "“THRAUPID (TANAGER)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(numerous genera) tanager, tanager-finch, conebill, flowerpiercer**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3865,7 +3865,7 @@
   },
   {
     "root": "NŠPŘ",
-    "refers": "\"THRAUPID (TANAGER)\" II",
+    "refers": "“THRAUPID (TANAGER)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Tersina, Cyanerpes, Chlorophanes, Iridophanes) honeycreeper**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3889,7 +3889,7 @@
   },
   {
     "root": "NŠPF",
-    "refers": "\"THRAUPID (TANAGER)\" III",
+    "refers": "“THRAUPID (TANAGER)” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Emberizoides, Embernagra) grass-finch, pampa-finch**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3913,7 +3913,7 @@
   },
   {
     "root": "NŠPV",
-    "refers": "\"THRAUPID (TANAGER)\" IV",
+    "refers": "“THRAUPID (TANAGER)” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Catamblyrhynchus) plushcap**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3937,7 +3937,7 @@
   },
   {
     "root": "MSTF",
-    "refers": "\"CARDINALID (CARDINAL)\" I",
+    "refers": "“CARDINALID (CARDINAL)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Cardinalis, Gubernatrix) cardinal**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3961,7 +3961,7 @@
   },
   {
     "root": "MSTV",
-    "refers": "\"CARDINALID (CARDINAL)\" II",
+    "refers": "“CARDINALID (CARDINAL)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Passerina) [North American] bunting**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",

--- a/lexicon/7.3.1.5.json
+++ b/lexicon/7.3.1.5.json
@@ -97,7 +97,7 @@
   },
   {
     "root": "PSGŘ",
-    "refers": "\"SAWFISH\" (genera Pristis, Anoxypristis)",
+    "refers": "“SAWFISH” (genera Pristis, Anoxypristis)",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(P. pristis) [largetooth, common, wide, freshwater, river, northern] sawfish / carpenter shark**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -193,7 +193,7 @@
   },
   {
     "root": "PSDY",
-    "refers": "\"SQUALIFORM SHARK\" I",
+    "refers": "“SQUALIFORM SHARK” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Squalids; genera Cirrhigaleus, Squalus) dogfish shark**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -217,7 +217,7 @@
   },
   {
     "root": "PSDL",
-    "refers": "\"SQUALIFORM SHARK\" II",
+    "refers": "“SQUALIFORM SHARK” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Etmopterids; several genera) lantern shark**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -337,7 +337,7 @@
   },
   {
     "root": "PSBW",
-    "refers": "\"LAMNIFORM SHARK\" I",
+    "refers": "“LAMNIFORM SHARK” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Alopius) thresher shark**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -361,7 +361,7 @@
   },
   {
     "root": "PSBY",
-    "refers": "\"LAMNIFORM SHARK\" II",
+    "refers": "“LAMNIFORM SHARK” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Mitsukurina) goblin shark**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -385,7 +385,7 @@
   },
   {
     "root": "PSBL",
-    "refers": "\"CARPET SHARK\" I",
+    "refers": "“CARPET SHARK” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Ginglymostomatids and Brachaelurids; numerous genera) nurse shark, blind shark**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -409,7 +409,7 @@
   },
   {
     "root": "PSBR",
-    "refers": "\"CARPET SHARK\" II",
+    "refers": "“CARPET SHARK” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Rhincodon) whale shark**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -601,7 +601,7 @@
   },
   {
     "root": "PSSGV",
-    "refers": "\"OSTEOGLOSSOID FISH\" I",
+    "refers": "“OSTEOGLOSSOID FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Arapaimids & Osteoglossids; genera Heterotis, Arapaima, Scleropages, Osteoglossum) bonytongue, arowana**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -625,7 +625,7 @@
   },
   {
     "root": "PSSGḐ",
-    "refers": "\"OSTEOGLOSSOID FISH\" II",
+    "refers": "“OSTEOGLOSSOID FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Notopterids; several genera) knifefish, featherback**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -721,7 +721,7 @@
   },
   {
     "root": "PSTL",
-    "refers": "\"LEUCISCINE FISH\" I",
+    "refers": "“LEUCISCINE FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(small Leuciscines; numerous genera) minnow**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -745,7 +745,7 @@
   },
   {
     "root": "PSTR",
-    "refers": "\"LEUCISCINE FISH\" II",
+    "refers": "“LEUCISCINE FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Abramis, Ballerus, Blicca) bream**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -769,7 +769,7 @@
   },
   {
     "root": "PSTŘ",
-    "refers": "\"LEUCISCINE FISH\" III",
+    "refers": "“LEUCISCINE FISH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Tica) tench, doctor fish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -793,7 +793,7 @@
   },
   {
     "root": "PSTÇ",
-    "refers": "\"LEUCISCINE FISH\" IV",
+    "refers": "“LEUCISCINE FISH” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Mylopharadon) hardhead**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -817,7 +817,7 @@
   },
   {
     "root": "PSTF",
-    "refers": "\"LEUCISCINE FISH\" V",
+    "refers": "“LEUCISCINE FISH” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Leucaspius) sunbleak, belica, moderlieschen**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -841,7 +841,7 @@
   },
   {
     "root": "PSTĻ",
-    "refers": "\"LEUCISCINE FISH\" VI",
+    "refers": "“LEUCISCINE FISH” VI",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Hybopsis, Semotilus, Squalius, Hemitremia, Platygobio, Nocomis, Couesius, Iotichthys, Snyderichthys, Oregonichthys, Petroleuciscus, Erimystax, Gila, Siphateles, Algansea) chub**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -865,7 +865,7 @@
   },
   {
     "root": "RPST",
-    "refers": "\"CYPRINID FISH (Other than Cyprinines and Leuciscines)\" I",
+    "refers": "“CYPRINID FISH (Other than Cyprinines and Leuciscines)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Acheilognathines; several genera) bitterling**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -889,7 +889,7 @@
   },
   {
     "root": "RPSTW",
-    "refers": "\"CYPRINID FISH (Other than Cyprinines and Leuciscines)\" II",
+    "refers": "“CYPRINID FISH (Other than Cyprinines and Leuciscines)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Barbines and Leptobarbines; numerous genera) barbine fish (including barbs, barbels, snowtrouts) and Leptobarbus**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -913,7 +913,7 @@
   },
   {
     "root": "RPSTY",
-    "refers": "\"CYPRINID FISH (Other than Cyprinines and Leuciscines)\" III",
+    "refers": "“CYPRINID FISH (Other than Cyprinines and Leuciscines)” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Danionines; numerous genera) danionine fish (including carplets, rasboras, flying barbs, razorbelly minnows)**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1033,7 +1033,7 @@
   },
   {
     "root": "ŘPSM",
-    "refers": "\"ERYTHINOID FISH\" I",
+    "refers": "“ERYTHINOID FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Tarumaniids; genus Tarumania) tarumania**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1057,7 +1057,7 @@
   },
   {
     "root": "ŘPSN",
-    "refers": "\"ERYTHINOID FISH\" II",
+    "refers": "“ERYTHINOID FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Hemiodontids; several genera) hemiodontid fish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1081,7 +1081,7 @@
   },
   {
     "root": "ŘPSŇ",
-    "refers": "\"ERYTHINOID FISH\" III",
+    "refers": "“ERYTHINOID FISH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Chilodontids; genera Caenotropus, Chilodus) headstander**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1105,7 +1105,7 @@
   },
   {
     "root": "ŘPSMW",
-    "refers": "\"CHARACID FISH\" I (including TETRA)",
+    "refers": "“CHARACID FISH” I (including TETRA)",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Characins; several genera) characin fish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1129,7 +1129,7 @@
   },
   {
     "root": "ŘPSNW",
-    "refers": "\"CHARACID FISH\" II",
+    "refers": "“CHARACID FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Ctenoluciids; genera Boulengerella, Ctenolucius) pike-characin**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1153,7 +1153,7 @@
   },
   {
     "root": "PSL",
-    "refers": "\"CATFISH\" I",
+    "refers": "“CATFISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Silurids; numerous genera) catfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1177,7 +1177,7 @@
   },
   {
     "root": "PSLW",
-    "refers": "\"CATFISH\" II",
+    "refers": "“CATFISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Pangasiids, Mochokids, Claroteids; numerous genera) shark catfish, African catfish, squeaker**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1273,7 +1273,7 @@
   },
   {
     "root": "PSKW",
-    "refers": "\"SALMONID FISH\" (other than salmon/trout/char)",
+    "refers": "“SALMONID FISH” (other than salmon/trout/char)",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Eurasian Salmonids; genera Hucho, Parahucho, Brachymystax) hucho, taimen/huchen, lenok**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1369,7 +1369,7 @@
   },
   {
     "root": "PSKŘ",
-    "refers": "\"STOMIIFORM\" FISH (other than Sternoptychids)",
+    "refers": "“STOMIIFORM” FISH (other than Sternoptychids)",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Gonostomatids; several genera) bristlemouth, anglemouth, fangjaw**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1393,7 +1393,7 @@
   },
   {
     "root": "RPSKW",
-    "refers": "\"ALEPISAUROID FISH\" I",
+    "refers": "“ALEPISAUROID FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Alepisaurus) lancetfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1417,7 +1417,7 @@
   },
   {
     "root": "RPSKY",
-    "refers": "\"ALEPISAUROID FISH\" II",
+    "refers": "“ALEPISAUROID FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Evermannellids; several genera) sabertooth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1441,7 +1441,7 @@
   },
   {
     "root": "RPSKL",
-    "refers": "\"AULOPIFORM FISH\" I",
+    "refers": "“AULOPIFORM FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Bathysauropsis, Bathysauroides) grinner**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1465,7 +1465,7 @@
   },
   {
     "root": "RPSKR",
-    "refers": "\"AULOPIFORM FISH\" II",
+    "refers": "“AULOPIFORM FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Notosudids; several genera) waryfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1537,7 +1537,7 @@
   },
   {
     "root": "PSSN",
-    "refers": "\"LAMPRIFORM FISH\" I",
+    "refers": "“LAMPRIFORM FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Veliferids; genera Velifer, Metavelifer) sailfin moonfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1561,7 +1561,7 @@
   },
   {
     "root": "PSSŇ",
-    "refers": "\"LAMPRIFORM FISH\" II",
+    "refers": "“LAMPRIFORM FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Lophotids; genera Lophotus, Eumecichthys) crestfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1609,7 +1609,7 @@
   },
   {
     "root": "PSKF",
-    "refers": "\"ZEIFORM FISH\" I",
+    "refers": "“ZEIFORM FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Zeids; genera Zeus, Zenopsis) dory**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1633,7 +1633,7 @@
   },
   {
     "root": "PSKV",
-    "refers": "\"ZEIFORM FISH\" II",
+    "refers": "“ZEIFORM FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Oreosomatids; several genera) oreo**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1657,7 +1657,7 @@
   },
   {
     "root": "PSP",
-    "refers": "\"GADID FISH\" I",
+    "refers": "“GADID FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Gadus) [true] cod**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1681,7 +1681,7 @@
   },
   {
     "root": "PSPW",
-    "refers": "\"GADID FISH\" II",
+    "refers": "“GADID FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Microgadus) tomcod**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1705,7 +1705,7 @@
   },
   {
     "root": "PSPY",
-    "refers": "\"GADID FISH\" III",
+    "refers": "“GADID FISH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Arctogadus, Boreogadus) arctic/polar cod**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1729,7 +1729,7 @@
   },
   {
     "root": "PSPL",
-    "refers": "\"LOTID FISH\" I",
+    "refers": "“LOTID FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Lota) burbot / bubbot / lingcod / mariah / eelpout / coneyfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1753,7 +1753,7 @@
   },
   {
     "root": "PSPR",
-    "refers": "\"LOTID FISH\" II",
+    "refers": "“LOTID FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Gaidropsaurus) rockling**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1873,7 +1873,7 @@
   },
   {
     "root": "PSC",
-    "refers": "\"BERYCIFORM FISH\" I",
+    "refers": "“BERYCIFORM FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Berycids; genus Beryx) alfonsino**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1897,7 +1897,7 @@
   },
   {
     "root": "PSČ",
-    "refers": "\"BERYCIFORM FISH\" II",
+    "refers": "“BERYCIFORM FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Cetomimids; numerous genera) flabby whalefish, tapetail, hairyfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1921,7 +1921,7 @@
   },
   {
     "root": "PŠČ",
-    "refers": "\"BERYCIFORM FISH\" III",
+    "refers": "“BERYCIFORM FISH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Melamphaids; several genera) ridgehead / bigscale**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1945,7 +1945,7 @@
   },
   {
     "root": "PSCW",
-    "refers": "\"TRACHICHTHYFORM FISH\" I",
+    "refers": "“TRACHICHTHYFORM FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Trachichthyids; several genera except Paratrychichthys) roughy, slimehead, redfish, sawbelly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1969,7 +1969,7 @@
   },
   {
     "root": "PSČW",
-    "refers": "\"TRACHICHTHYFORM FISH\" II",
+    "refers": "“TRACHICHTHYFORM FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Anoplogastrids; genus Anoplogaster) fangtooth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2089,7 +2089,7 @@
   },
   {
     "root": "LPŠTL",
-    "refers": "\"GOBIOID FISH\" I",
+    "refers": "“GOBIOID FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Gobiines, Benthophilines, Gobionellines, Sicydiines; numerous genera) goby**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2113,7 +2113,7 @@
   },
   {
     "root": "LPŠTR",
-    "refers": "\"GOBIOID FISH\" II",
+    "refers": "“GOBIOID FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Ptereleotrines; numerous genera) dartfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2137,7 +2137,7 @@
   },
   {
     "root": "LPŠTŘ",
-    "refers": "\"GOBIOID FISH\" III",
+    "refers": "“GOBIOID FISH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Thalasseleotridids; genera Thalasseleotris, Grahamichthys) gudgeon**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2161,7 +2161,7 @@
   },
   {
     "root": "LPŠTÇ",
-    "refers": "\"GOBIOID FISH\" IV",
+    "refers": "“GOBIOID FISH” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Rhyacichthyids; genera Protogobius, Rhyacichthys) loach-goby**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2209,7 +2209,7 @@
   },
   {
     "root": "KŢSP",
-    "refers": "\"SCOMBRIFORM FISH\" I",
+    "refers": "“SCOMBRIFORM FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Bramids; several genera) pomfret, fanfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2233,7 +2233,7 @@
   },
   {
     "root": "KŢST",
-    "refers": "\" SCOMBRIFORM FISH\" II",
+    "refers": "“ SCOMBRIFORM FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Scombrolabracids; genus Scombrolabrax) longfin escolar / black mackerel**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2257,7 +2257,7 @@
   },
   {
     "root": "KŢSK",
-    "refers": "\"SCOMBRIFORM FISH\" III",
+    "refers": "“SCOMBRIFORM FISH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Centrolophids; several genera) medusafish, ruff, rudderfish, blackfish, barrelfish, butterfish, warehou / trevalla**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2281,7 +2281,7 @@
   },
   {
     "root": "KŢSB",
-    "refers": "\"SCOMBRIFORM FISH\" IV",
+    "refers": "“SCOMBRIFORM FISH” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Sphyraena) barracuda**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2329,7 +2329,7 @@
   },
   {
     "root": "KŢSG",
-    "refers": "\"SYNGNATHIFORM FISH\" I",
+    "refers": "“SYNGNATHIFORM FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Hippocampus) seahorse**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2353,7 +2353,7 @@
   },
   {
     "root": "KŢSF",
-    "refers": "\"SYNGNATHIFORM FISH\" II",
+    "refers": "“SYNGNATHIFORM FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Pegasids; genus Pegasus, Euypegasus) seamoth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2377,7 +2377,7 @@
   },
   {
     "root": "KŢSV",
-    "refers": "\"SYNGNATHIFORM FISH\" III",
+    "refers": "“SYNGNATHIFORM FISH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Mullids; several genera) goatfish / red mullet**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2401,7 +2401,7 @@
   },
   {
     "root": "KŢSM",
-    "refers": "\"SYNGNATHIFORM FISH\" IV",
+    "refers": "“SYNGNATHIFORM FISH” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Macroramphosids; genus Macroramphosus) snipefish / bellowfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2497,7 +2497,7 @@
   },
   {
     "root": "PŢS",
-    "refers": "\"CARANGID FISH\" I",
+    "refers": "“CARANGID FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Lichia) leerfish / garrick**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2521,7 +2521,7 @@
   },
   {
     "root": "PŢSP",
-    "refers": "\"CARANGID FISH\" II",
+    "refers": "“CARANGID FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Oligoplites, Parona) leatherjacket**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2545,7 +2545,7 @@
   },
   {
     "root": "PŢST",
-    "refers": "\"CARANGID FISH\" III",
+    "refers": "“CARANGID FISH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Naucrates) pilot fish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2569,7 +2569,7 @@
   },
   {
     "root": "PŢSK",
-    "refers": "\"CARANGID FISH\" IV",
+    "refers": "“CARANGID FISH” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Alectis) threadfish, diamond trevally**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2593,7 +2593,7 @@
   },
   {
     "root": "PŢSB",
-    "refers": "\"CARANGID FISH\" V",
+    "refers": "“CARANGID FISH” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Caranx, Carangoides, Hemicaranx) jack, trevally, bludger**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2617,7 +2617,7 @@
   },
   {
     "root": "PŢSD",
-    "refers": "\"CARANGID FISH\" VI",
+    "refers": "“CARANGID FISH” VI",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Decapterus) mackerel scad, round scad, roughear scad, Indian scad, redtail scad, Japanese scad, shortfin scad, koheru**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2641,7 +2641,7 @@
   },
   {
     "root": "PŢSG",
-    "refers": "\"CARANGID FISH\" VII",
+    "refers": "“CARANGID FISH” VII",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Pantolebus) fringefin trevally / round-finned trevally / reef herring**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2665,7 +2665,7 @@
   },
   {
     "root": "PŢSF",
-    "refers": "\"CARANGID FISH\" VIII",
+    "refers": "“CARANGID FISH” VIII",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Selar) oxeye scad, bigeye scad**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2689,7 +2689,7 @@
   },
   {
     "root": "PŢSV",
-    "refers": "\"CARANGID FISH\" IX",
+    "refers": "“CARANGID FISH” IX",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Trachurus) saurel / jack mackerel**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2713,7 +2713,7 @@
   },
   {
     "root": "PŢSM",
-    "refers": "\"CARANGIFORM FISH\" I",
+    "refers": "“CARANGIFORM FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Nematistius) roosterfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2737,7 +2737,7 @@
   },
   {
     "root": "PŢSN",
-    "refers": "\"CARANGIFORM FISH\" II",
+    "refers": "“CARANGIFORM FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Echeneids; several genera) remora / suckerfish, lousefish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2761,7 +2761,7 @@
   },
   {
     "root": "PŢSŇ",
-    "refers": "\"CARANGIFORM FISH\" III",
+    "refers": "“CARANGIFORM FISH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Polynemids; several genera) threadfin, bobo, barbu, paradise fish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2785,7 +2785,7 @@
   },
   {
     "root": "PŠK",
-    "refers": "\"PLEURONECTID FISH (RIGHTEYE FLOUNDER)\" I",
+    "refers": "“PLEURONECTID FISH (RIGHTEYE FLOUNDER)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Hippoglossus hippoglossus) Atlantic halibut**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2809,7 +2809,7 @@
   },
   {
     "root": "PŠKW",
-    "refers": "\"PLEURONECTID FISH (RIGHTEYE FLOUNDER)\" II",
+    "refers": "“PLEURONECTID FISH (RIGHTEYE FLOUNDER)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Hippoglossoides) American plaice, flathead flounder, flathead sole, Bering flounder**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2833,7 +2833,7 @@
   },
   {
     "root": "PŠKY",
-    "refers": "\"PLEURONECTID FISH (RIGHTEYE FLOUNDER)\" III",
+    "refers": "“PLEURONECTID FISH (RIGHTEYE FLOUNDER)” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Microstomus) lemon sole, Pacific Dover sole, slime flounder**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2857,7 +2857,7 @@
   },
   {
     "root": "PŠKL",
-    "refers": "\"PLEURONECTID FISH (RIGHTEYE FLOUNDER)\" IV",
+    "refers": "“PLEURONECTID FISH (RIGHTEYE FLOUNDER)” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Embassichthys) deepsea sole**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2881,7 +2881,7 @@
   },
   {
     "root": "PŠKR",
-    "refers": "\"PLEURONECTID FISH (RIGHTEYE FLOUNDER)\" V",
+    "refers": "“PLEURONECTID FISH (RIGHTEYE FLOUNDER)” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Lepidopsetta) rocksole, dusky sole, Northern rock sole**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2905,7 +2905,7 @@
   },
   {
     "root": "PŠKŘ",
-    "refers": "\"PLEURONECTID FISH (RIGHTEYE FLOUNDER)\" VI",
+    "refers": "“PLEURONECTID FISH (RIGHTEYE FLOUNDER)” VI",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Glyptocephalus zachirus) rex sole**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2929,7 +2929,7 @@
   },
   {
     "root": "PŠKÇ",
-    "refers": "\"PLEURONECTID FISH (RIGHTEYE FLOUNDER)\" VII",
+    "refers": "“PLEURONECTID FISH (RIGHTEYE FLOUNDER)” VII",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Pleuronichthys) curlfin sole, C-O sole, ridge-eyed flounder, ocellated turbot, spotted turbot, horny-head turbot**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2953,7 +2953,7 @@
   },
   {
     "root": "PŠKF",
-    "refers": "\"PLEURONECTID FISH (RIGHTEYE FLOUNDER)\" VIII",
+    "refers": "“PLEURONECTID FISH (RIGHTEYE FLOUNDER)” VIII",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Kereius) stone flounder**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2977,7 +2977,7 @@
   },
   {
     "root": "PŠKH",
-    "refers": "\"PLEURONECTID FISH (RIGHTEYE FLOUNDER)\" IX",
+    "refers": "“PLEURONECTID FISH (RIGHTEYE FLOUNDER)” IX",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Pseudopleuronectes) winter flounder, yellow-striped flounder, cresthead flounder, marbled flounder**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3001,7 +3001,7 @@
   },
   {
     "root": "PŠKŢ",
-    "refers": "\"PLEURONECTID FISH (RIGHTEYE FLOUNDER)\" X",
+    "refers": "“PLEURONECTID FISH (RIGHTEYE FLOUNDER)” X",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Paralichthodes) peppered flounder / measles flounder**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3025,7 +3025,7 @@
   },
   {
     "root": "PŠKM",
-    "refers": "\"RHOMBOSOLEID FISH (SOUTHERN HEMISPHERE RIGHTEYE FLOUNDER)\" I",
+    "refers": "“RHOMBOSOLEID FISH (SOUTHERN HEMISPHERE RIGHTEYE FLOUNDER)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Ammotretis) shortfin flounder, elongate flounder, Tudor's flounder, longsnout flounder**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3049,7 +3049,7 @@
   },
   {
     "root": "PŠKN",
-    "refers": "\"RHOMBOSOLEID FISH (SOUTHERN HEMISPHERE RIGHTEYE FLOUNDER)\" II",
+    "refers": "“RHOMBOSOLEID FISH (SOUTHERN HEMISPHERE RIGHTEYE FLOUNDER)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Colistium) New Zealand brill, New Zealand turbot**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3073,7 +3073,7 @@
   },
   {
     "root": "PŠKV",
-    "refers": "\"RHOMBOSOLEID FISH (SOUTHERN HEMISPHERE RIGHTEYE FLOUNDER)\" III",
+    "refers": "“RHOMBOSOLEID FISH (SOUTHERN HEMISPHERE RIGHTEYE FLOUNDER)” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Rhombosolea) yellowbelly flounder, sand flounder, black flounder, greenback flounder**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3121,7 +3121,7 @@
   },
   {
     "root": "LPSB",
-    "refers": "\"BOTHID FISH (LEFTEYE FLOUNDER)\" II",
+    "refers": "“BOTHID FISH (LEFTEYE FLOUNDER)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Engyophrys) speckled-tail flounder, American spiny flounder**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3145,7 +3145,7 @@
   },
   {
     "root": "LPSG",
-    "refers": "\"BOTHID FISH (LEFTEYE FLOUNDER)\" III",
+    "refers": "“BOTHID FISH (LEFTEYE FLOUNDER)” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Kamoharaia) wide-mouthed flounder**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3169,7 +3169,7 @@
   },
   {
     "root": "LPSD",
-    "refers": "\"BOTHID FISH (LEFTEYE FLOUNDER)\" IV",
+    "refers": "“BOTHID FISH (LEFTEYE FLOUNDER)” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Lophonectes) crested flounder**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3193,7 +3193,7 @@
   },
   {
     "root": "LPSC",
-    "refers": "\"PARALYCHTHYID FISH (LARGE-TOOTH FLOUNDER)\" I",
+    "refers": "“PARALYCHTHYID FISH (LARGE-TOOTH FLOUNDER)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Ancylopsetta) Cyclope founder, three-spot flounder, three-eye flounder, four-eyed flounder, Gulf of Mexico ocellated flounder**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3217,7 +3217,7 @@
   },
   {
     "root": "LPSČ",
-    "refers": "\"PARALYCHTHYID FISH (LARGE-TOOTH FLOUNDER)\" II",
+    "refers": "“PARALYCHTHYID FISH (LARGE-TOOTH FLOUNDER)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Etropus) fringed flounder, shelf flounder, smallmouth flounder, Peruvian flounder, gray flounder, sole flounder, Delsman's flounder**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3241,7 +3241,7 @@
   },
   {
     "root": "LPSY",
-    "refers": "\"PARALYCHTHYID FISH (LARGE-TOOTH FLOUNDER)\" III",
+    "refers": "“PARALYCHTHYID FISH (LARGE-TOOTH FLOUNDER)” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Paralichthys) fine flounder, Cortez flounder, gulf flounder, Brasilian flounder, California flounder, summer flounder, fluke, bastard halibut, Patagonian flounder, broad flounder, tropical flounder, speckled flounder, olive flounder**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3265,7 +3265,7 @@
   },
   {
     "root": "LPSŘ",
-    "refers": "\"PARALYCHTHYID FISH (LARGE-TOOTH FLOUNDER)\" IV",
+    "refers": "“PARALYCHTHYID FISH (LARGE-TOOTH FLOUNDER)” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Tephrinectes) Chinese brill**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3409,7 +3409,7 @@
   },
   {
     "root": "PŠTW",
-    "refers": "\"SOLEID FISH (TRUE SOLE)\" I",
+    "refers": "“SOLEID FISH (TRUE SOLE)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Solea solea) common sole**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3433,7 +3433,7 @@
   },
   {
     "root": "PŠTY",
-    "refers": "\"SOLEID FISH (TRUE SOLE)\" II",
+    "refers": "“SOLEID FISH (TRUE SOLE)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Buglossidium) yellow sole / solonette**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3457,7 +3457,7 @@
   },
   {
     "root": "PŠTL",
-    "refers": "\"SOLEID FISH (TRUE SOLE)\" III",
+    "refers": "“SOLEID FISH (TRUE SOLE)” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Heteromycteris) Cape sole, hook-nosed sole, bamboo sole, true sole**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3481,7 +3481,7 @@
   },
   {
     "root": "PŠTR",
-    "refers": "\"SOLEID FISH (TRUE SOLE)\" IV",
+    "refers": "“SOLEID FISH (TRUE SOLE)” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Monochirus) whiskered sole**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3505,7 +3505,7 @@
   },
   {
     "root": "PŠTŘ",
-    "refers": "\"SOLEID FISH (TRUE SOLE)\" V",
+    "refers": "“SOLEID FISH (TRUE SOLE)” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Aesopia, Pseudoaesopia, Zebria) zebra sole, unicorn sole, banded sole, thickray sole, wavyband sole**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3529,7 +3529,7 @@
   },
   {
     "root": "PŠTÇ",
-    "refers": "\"SOLEID FISH (TRUE SOLE)\" VI",
+    "refers": "“SOLEID FISH (TRUE SOLE)” VI",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Soleichthys) whiteblotched sole, small-head sole, banded-eye sole, snakeskin sole**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3673,7 +3673,7 @@
   },
   {
     "root": "PSSKL",
-    "refers": "\"BELONIFORM FISH\" I",
+    "refers": "“BELONIFORM FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Adrianichthyids; several genera) ricefish, medaka**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3697,7 +3697,7 @@
   },
   {
     "root": "PSSKR",
-    "refers": "\"BELONIFORM FISH\" II",
+    "refers": "“BELONIFORM FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Scomberesocids; genera Cololabis, Scomberesox) saury**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3937,7 +3937,7 @@
   },
   {
     "root": "LPSTL",
-    "refers": "\"PLESIOPID FISH (LONGFIN / ROUNDHEAD)\" I",
+    "refers": "“PLESIOPID FISH (LONGFIN / ROUNDHEAD)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Acanthoclinus) rockfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3961,7 +3961,7 @@
   },
   {
     "root": "LPSTR",
-    "refers": "\"PLESIOPID FISH (LONGFIN / ROUNDHEAD)\" II",
+    "refers": "“PLESIOPID FISH (LONGFIN / ROUNDHEAD)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Belonepterygion) barred spiny basslet**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3985,7 +3985,7 @@
   },
   {
     "root": "LPSTŘ",
-    "refers": "\"PLESIOPID FISH (LONGFIN / ROUNDHEAD)\" III",
+    "refers": "“PLESIOPID FISH (LONGFIN / ROUNDHEAD)” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Calloplesiops) comet / marine betta**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4009,7 +4009,7 @@
   },
   {
     "root": "LPSTÇ",
-    "refers": "\"PLESIOPID FISH (LONGFIN / ROUNDHEAD)\" IV",
+    "refers": "“PLESIOPID FISH (LONGFIN / ROUNDHEAD)” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Plesiops) longfin, prettyfin**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4081,7 +4081,7 @@
   },
   {
     "root": "LPSPY",
-    "refers": "\"POMACENTRINE FISH\" I",
+    "refers": "“POMACENTRINE FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Abudefduf) sergeant, sergeant-major, nightsergeant**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4105,7 +4105,7 @@
   },
   {
     "root": "LPSPL",
-    "refers": "\"POMACENTRINE FISH\" II",
+    "refers": "“POMACENTRINE FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Parma) scalyfin, New Zealand black angelfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4129,7 +4129,7 @@
   },
   {
     "root": "PSSP",
-    "refers": "\"BLENNIOID FISH\" I",
+    "refers": "“BLENNIOID FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Blenniids and Labrisomids; numerous genera) blenny, rockskipper, combtooth blenny**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4153,7 +4153,7 @@
   },
   {
     "root": "PSSPW",
-    "refers": "\"BLENNIOID FISH\" II",
+    "refers": "“BLENNIOID FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Clinids; numerous genera) klipfish, cline, weedfish, kelpfish, eel blenny**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4201,7 +4201,7 @@
   },
   {
     "root": "PSSPL",
-    "refers": "\"LABRID FISH (WRASSE)\" I",
+    "refers": "“LABRID FISH (WRASSE)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Halichoeres and numerous other genera) wrasse**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4225,7 +4225,7 @@
   },
   {
     "root": "PSSPR",
-    "refers": "\"LABRID FISH (WRASSE)\" II",
+    "refers": "“LABRID FISH (WRASSE)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Xyrichtys) razorfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4249,7 +4249,7 @@
   },
   {
     "root": "PSSPŘ",
-    "refers": "\"LABRID FISH (WRASSE)\" III",
+    "refers": "“LABRID FISH (WRASSE)” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Tautoga) tautog, blackfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4273,7 +4273,7 @@
   },
   {
     "root": "PSSPÇ",
-    "refers": "\"LABRID FISH (WRASSE)\" IV",
+    "refers": "“LABRID FISH (WRASSE)” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Labrichthys) tubelip wrasse**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4321,7 +4321,7 @@
   },
   {
     "root": "PSSPŢ",
-    "refers": "\"TRACHINIFORM FISH\" I",
+    "refers": "“TRACHINIFORM FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Trachinids; genera Trachinus, Echichthys) weever / weeverfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4345,7 +4345,7 @@
   },
   {
     "root": "PSSPĻ",
-    "refers": "\"TRACHINIFORM FISH\" II",
+    "refers": "“TRACHINIFORM FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Chiasmodontids; several genera) snaketooth fish / swallower**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4369,7 +4369,7 @@
   },
   {
     "root": "PSSPV",
-    "refers": "\"TRACHINIFORM FISH\" III",
+    "refers": "“TRACHINIFORM FISH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Leptoscopids; genera Crapatalus, Leptoscopus, Lesueuina) southern sandfish, flathead pygmy-stargazer, estuary stargazer**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4393,7 +4393,7 @@
   },
   {
     "root": "PSSPH",
-    "refers": "\"TRACHINIFORM FISH\" IV",
+    "refers": "“TRACHINIFORM FISH” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Trichodontids; genera Trichodon, Arctoscopus) sandfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4417,7 +4417,7 @@
   },
   {
     "root": "RPSP",
-    "refers": "\"CENTRARCHID FISH\" I",
+    "refers": "“CENTRARCHID FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Lepomis) sunfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4441,7 +4441,7 @@
   },
   {
     "root": "RPSPW",
-    "refers": "\"CENTRARCHID FISH\" II",
+    "refers": "“CENTRARCHID FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Enneacanthus) banded sunfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4465,7 +4465,7 @@
   },
   {
     "root": "RPSPY",
-    "refers": "\"CENTRARCHID FISH\" III",
+    "refers": "“CENTRARCHID FISH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Ambloplites) rock bass, shadow bass, Roanoke bass, Ozark bass**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4489,7 +4489,7 @@
   },
   {
     "root": "RPSPL",
-    "refers": "\"CENTRARCHIFORM FISH\" I",
+    "refers": "“CENTRARCHIFORM FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Aplodactylids; genus Aplodactylus) marblefish, sea carp, rock cale**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4513,7 +4513,7 @@
   },
   {
     "root": "RPSPR",
-    "refers": "\" CENTRARCHIFORM FISH\" II",
+    "refers": "“ CENTRARCHIFORM FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Cirrhitids; numerous genera) hawkfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4537,7 +4537,7 @@
   },
   {
     "root": "RPSPŘ",
-    "refers": "\"CENTRARCHIFORM FISH\" III",
+    "refers": "“CENTRARCHIFORM FISH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Enoplosids; genus Enoplosus) old wife**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4561,7 +4561,7 @@
   },
   {
     "root": "RPSPH",
-    "refers": "\"CENTRARCHIFORM FISH\" IV",
+    "refers": "“CENTRARCHIFORM FISH” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Kyphosines; several genera) sea chub**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4585,7 +4585,7 @@
   },
   {
     "root": "RPSB",
-    "refers": "\"CENTRARCHIFORM FISH\" V",
+    "refers": "“CENTRARCHIFORM FISH” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Oplegnathids; genus Oplegnatus) knifejaw**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4609,7 +4609,7 @@
   },
   {
     "root": "PSSC",
-    "refers": "\"TETRADONTIFORM FISH\" I",
+    "refers": "“TETRADONTIFORM FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Tetradontids and Triodontids; numerous genera) puffer, pufferfish, blowfish, globefish, balloonfish, blowie, bubble fish, swellfish, toadfish, toady, honey toad, sugar toad, sea squab, toby, blaasop**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4633,7 +4633,7 @@
   },
   {
     "root": "PSSČ",
-    "refers": "\"TETRADONTIFORM FISH\" II",
+    "refers": "“TETRADONTIFORM FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Balistids; numerous genera) triggerfish, picasso fish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4657,7 +4657,7 @@
   },
   {
     "root": "PŠŠČ",
-    "refers": "\"TETRADONTIFORM FISH\" III",
+    "refers": "“TETRADONTIFORM FISH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Molids; genera Mola, Mastrurus, Ranzania) sunfish / mola**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4681,7 +4681,7 @@
   },
   {
     "root": "PSST",
-    "refers": "\"SCORPAENIFORM FISH\" I",
+    "refers": "“SCORPAENIFORM FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Scorpaenids; numerous genera) scorpionfish, rock fish, red rock cod**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4705,7 +4705,7 @@
   },
   {
     "root": "PSSTW",
-    "refers": "\"SCORPAENIFORM FISH\" II",
+    "refers": "“SCORPAENIFORM FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Dendrochirus) lionfish, firefish, turkey fish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4729,7 +4729,7 @@
   },
   {
     "root": "PSSTY",
-    "refers": "\" SCORPAENIFORM FISH\" III",
+    "refers": "“ SCORPAENIFORM FISH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Apistids and Tetrarogids; numerous genera) wasp scorpionfish, waspfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4753,7 +4753,7 @@
   },
   {
     "root": "PSSTL",
-    "refers": "\"SCORPAENIFORM FISH\" IV",
+    "refers": "“SCORPAENIFORM FISH” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Gymnapistes) cobbler / estuary cobbler**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4777,7 +4777,7 @@
   },
   {
     "root": "PSSTR",
-    "refers": "\" SCORPAENIFORM FISH\" V",
+    "refers": "“ SCORPAENIFORM FISH” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Agonids, Bathyagonines and Bothragonines; several genera) poacher, snailfish, starsnout, rockhead**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4801,7 +4801,7 @@
   },
   {
     "root": "PSSTŘ",
-    "refers": "\"SCORPAENIFORM FISH\" VI",
+    "refers": "“SCORPAENIFORM FISH” VI",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Anoplopomatids; genera Anoplopoma, Erilepsis) sablefish / butterfish /black cod / blue cod /bluefish / candlefish /coal cod / coalfish / beshow, skilfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4825,7 +4825,7 @@
   },
   {
     "root": "PSSTÇ",
-    "refers": "\"SCORPAENIFORM FISH\" VII",
+    "refers": "“SCORPAENIFORM FISH” VII",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Sebastids; several genera) rockfish, rock perch, ocean perch, sea perch, thornyhead, sea ruffe, rockcod**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4849,7 +4849,7 @@
   },
   {
     "root": "PSSTF",
-    "refers": "\"SCORPAENIFORM FISH\" VIII",
+    "refers": "“SCORPAENIFORM FISH” VIII",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Synanceids; numerous genera) stonefish, stinger, stingfish, ghoul, devilfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4873,7 +4873,7 @@
   },
   {
     "root": "PSSTH",
-    "refers": "\"SCORPAENIFORM FISH\" IX",
+    "refers": "“SCORPAENIFORM FISH” IX",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Eschmeyerids; genus Eschmeyer) cofish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4897,7 +4897,7 @@
   },
   {
     "root": "PSSTĻ",
-    "refers": "\"SCORPAENIFORM FISH\" X",
+    "refers": "“SCORPAENIFORM FISH” X",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Aploactinids and Gnathanacanthids; numerous genera) velvetfish, red velvetfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4921,7 +4921,7 @@
   },
   {
     "root": "PSSDL",
-    "refers": "\"COTTOID FISH (SCULPIN)\" I",
+    "refers": "“COTTOID FISH (SCULPIN)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Cottids; numerous species) sculpin, bullhead, cabezon**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4945,7 +4945,7 @@
   },
   {
     "root": "PSSDR",
-    "refers": "\"COTTOID FISH (SCULPIN)\" II",
+    "refers": "“COTTOID FISH (SCULPIN)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Icelids; genus Icelus) scaled sculpin**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4969,7 +4969,7 @@
   },
   {
     "root": "PSSDŘ",
-    "refers": "\"COTTOID FISH (SCULPIN)\" III",
+    "refers": "“COTTOID FISH (SCULPIN)” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Ereuniids; genera Ereunias, Marukawichthys) deepwater bullhead sculpin**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4993,7 +4993,7 @@
   },
   {
     "root": "PSSDV",
-    "refers": "\"COTTOID FISH (SCULPIN)\" IV",
+    "refers": "“COTTOID FISH (SCULPIN)” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Cyclopterids; several genera) lumpsucker / lumpfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5065,7 +5065,7 @@
   },
   {
     "root": "PSSBW",
-    "refers": "\"LOPHIIFORM FISH (ANGLERFISH)\" I",
+    "refers": "“LOPHIIFORM FISH (ANGLERFISH)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Lophiids; several genera) angler, goosefish, monkfish, sea-devil**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5089,7 +5089,7 @@
   },
   {
     "root": "PSSBY",
-    "refers": "\"LOPHIIFORM FISH (ANGLERFISH)\" II",
+    "refers": "“LOPHIIFORM FISH (ANGLERFISH)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Antennariines and Lophichthyids; several genera) frogfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5113,7 +5113,7 @@
   },
   {
     "root": "PSSBL",
-    "refers": "\"LOPHIIFORM FISH (ANGLERFISH)\" III",
+    "refers": "“LOPHIIFORM FISH (ANGLERFISH)” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Ogcocephalids; numerous genera) batfish, seabat**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5137,7 +5137,7 @@
   },
   {
     "root": "PSSBR",
-    "refers": "\"LOPHIIFORM FISH (ANGLERFISH)\" IV",
+    "refers": "“LOPHIIFORM FISH (ANGLERFISH)” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Ceratiids; genera Ceratias, Cryptopsaras) warty seadevil**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5161,7 +5161,7 @@
   },
   {
     "root": "PSSBŘ",
-    "refers": "\"LOPHIIFORM FISH (ANGLERFISH)\" V",
+    "refers": "“LOPHIIFORM FISH (ANGLERFISH)” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Caulophrynids; genera Caulophryne, Robia) fanfin / hairy anglerfish / fanfin seadevil**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5185,7 +5185,7 @@
   },
   {
     "root": "PSSBV",
-    "refers": "\"LOPHIIFORM FISH (ANGLERFISH)\" VI",
+    "refers": "“LOPHIIFORM FISH (ANGLERFISH)” VI",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Oneirodids; numerous genera) dreamer, dreamarm, tyrant devil**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5281,7 +5281,7 @@
   },
   {
     "root": "PŠPL",
-    "refers": "\"ACANTHUROID FISH\" I",
+    "refers": "“ACANTHUROID FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genera Acanthuris, Ctenochaetus, Prionurus, Paracanthurus) surgeonfish, sawtail, doctorfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5305,7 +5305,7 @@
   },
   {
     "root": "PŠPR",
-    "refers": "\"ACANTHUROID FISH\" II",
+    "refers": "“ACANTHUROID FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Siganids; genus Siganus) rabbitfish / spinefoot**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5329,7 +5329,7 @@
   },
   {
     "root": "PŠPŘ",
-    "refers": "\"ACANTHUROID FISH\" III",
+    "refers": "“ACANTHUROID FISH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Ephippids; several genera) spadefish, batfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5425,7 +5425,7 @@
   },
   {
     "root": "PSKH",
-    "refers": "\"ZOARCOID FISH\" I",
+    "refers": "“ZOARCOID FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Anarhichadids; genera Anarhichas, Anarrhyichthys) wolffish / sea wolf, wolf eel**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5449,7 +5449,7 @@
   },
   {
     "root": "PSKM",
-    "refers": "\"ZOARCOID FISH\" II",
+    "refers": "“ZOARCOID FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Cryptacanthodids; genus Cryptacanthodes) wrymouth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5473,7 +5473,7 @@
   },
   {
     "root": "PSKŢ",
-    "refers": "\"ZOARCOID FISH\" III",
+    "refers": "“ZOARCOID FISH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Pholids; several genera) gunnel**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5497,7 +5497,7 @@
   },
   {
     "root": "PŠTĻ",
-    "refers": "\"NOTOTHENIOID FISH\" I",
+    "refers": "“NOTOTHENIOID FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Nototheniids; numerous genera) cod icefish / notothen, icedevil, toothfish, notie, rockcod, Antarctic silverfish, southern cod, scalyhead**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5521,7 +5521,7 @@
   },
   {
     "root": "PŠTV",
-    "refers": "\"NOTOTHENIOID FISH\" II",
+    "refers": "“NOTOTHENIOID FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Pseudaphritids; genus Pseudaphritis) congoli / tupong, catadromous icefish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5545,7 +5545,7 @@
   },
   {
     "root": "PŠPĻ",
-    "refers": "\"NOTOTHENIOID FISH\" III",
+    "refers": "“NOTOTHENIOID FISH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Harpagiferids; genus Harpagifer) spiny plunderfish / plunderfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5569,7 +5569,7 @@
   },
   {
     "root": "PŠTHW",
-    "refers": "\"PEMPHERIFORM FISH\" I",
+    "refers": "“PEMPHERIFORM FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Phempherids; genera Pempheris, Parapriacanthus) sweeper, bullseye**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5593,7 +5593,7 @@
   },
   {
     "root": "PŠKHW",
-    "refers": "\"PEMPHERIFORM FISH\" II",
+    "refers": "“PEMPHERIFORM FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Epigonids; several genera) deepwater cardinalfish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5617,7 +5617,7 @@
   },
   {
     "root": "PŠPHW",
-    "refers": "\"PEMPHERIFORM FISH\" III",
+    "refers": "“PEMPHERIFORM FISH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Howellids; several genera) oceanic basslet**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5641,7 +5641,7 @@
   },
   {
     "root": "RPŠK",
-    "refers": "\"MISCELLANEOUS PERCOMORPHARIAN FISH\" I",
+    "refers": "“MISCELLANEOUS PERCOMORPHARIAN FISH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Gerreids; several genera) mojarra**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5665,7 +5665,7 @@
   },
   {
     "root": "RPŠKW",
-    "refers": "\"MISCELLANEOUS PERCOMORPHARIAN FISH\" II",
+    "refers": "“MISCELLANEOUS PERCOMORPHARIAN FISH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Lateolabracids, genus Lateolabrax) Asian seabass**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5689,7 +5689,7 @@
   },
   {
     "root": "RPŠKY",
-    "refers": "\"MISCELLANEOUS PERCOMORPHARIAN FISH\" III",
+    "refers": "“MISCELLANEOUS PERCOMORPHARIAN FISH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Moronids; genera Morone, Dicentrarchus) temperate bass, white perch**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5713,7 +5713,7 @@
   },
   {
     "root": "RPŠKL",
-    "refers": "\"MISCELLANEOUS PERCOMORPHARIAN FISH\" IV",
+    "refers": "“MISCELLANEOUS PERCOMORPHARIAN FISH” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Caristiids; several genera) manefish**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5737,7 +5737,7 @@
   },
   {
     "root": "RPŠKR",
-    "refers": "\"MISCELLANEOUS PERCOMORPHARIAN FISH\" V",
+    "refers": "“MISCELLANEOUS PERCOMORPHARIAN FISH” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Arripids; genus Arripis) ruff / Australian herring, Australian salmon, kahawai**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5761,7 +5761,7 @@
   },
   {
     "root": "RPŠKŘ",
-    "refers": "\"MISCELLANEOUS PERCOMORPHARIAN FISH\" VI",
+    "refers": "“MISCELLANEOUS PERCOMORPHARIAN FISH” VI",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Dinolestids; genus Dinolestes) long-finned pike / yellowfin pike**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5785,7 +5785,7 @@
   },
   {
     "root": "RPŠKH",
-    "refers": "\"MISCELLANEOUS PERCOMORPHARIAN FISH\" VII",
+    "refers": "“MISCELLANEOUS PERCOMORPHARIAN FISH” VII",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Sciaenids; numerous genera) drum, croaker, sheephead, wuss fish, shepherd's pie, gou, Gasper goo, grinder, meagre, kob, mulloway, weakfish, bahaba, corvina, spot, king fish, curbinata, pacora, drummer, red, queenfish, stardrum, totoaba / totuava**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5809,7 +5809,7 @@
   },
   {
     "root": "RPŠG",
-    "refers": "\"MISCELLANEOUS PERCOMORPHARIAN FISH\" VIII",
+    "refers": "“MISCELLANEOUS PERCOMORPHARIAN FISH” VIII",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Pomatomids; genus Pomatomus) bluefish, tailor, elf**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",

--- a/lexicon/7.3.1.7.json
+++ b/lexicon/7.3.1.7.json
@@ -25,7 +25,7 @@
   },
   {
     "root": "LŢPW",
-    "refers": "\"DISEASE-CAUSING NEMATODE\" I",
+    "refers": "“DISEASE-CAUSING NEMATODE” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Trichinella) trichinella / trichina worm**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -50,7 +50,7 @@
   },
   {
     "root": "LŢPY",
-    "refers": "\"DISEASE-CAUSING NEMATODE\" II",
+    "refers": "“DISEASE-CAUSING NEMATODE” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Ascaris) ascaris / large roundworm**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -75,7 +75,7 @@
   },
   {
     "root": "LŢPL",
-    "refers": "\"DISEASE-CAUSING NEMATODE\" III",
+    "refers": "“DISEASE-CAUSING NEMATODE” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Dirofilaria) dirofilaria**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -100,7 +100,7 @@
   },
   {
     "root": "LŢPR",
-    "refers": "\"DISEASE-CAUSING NEMATODE\" IV",
+    "refers": "“DISEASE-CAUSING NEMATODE” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Mansonella) mansonella**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -125,7 +125,7 @@
   },
   {
     "root": "LŢPŘ",
-    "refers": "\"DISEASE-CAUSING NEMATODE\" V",
+    "refers": "“DISEASE-CAUSING NEMATODE” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Dracunculus) guinea worm**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -150,7 +150,7 @@
   },
   {
     "root": "LŢPÇ",
-    "refers": "\"DISEASE-CAUSING NEMATODE\" VI",
+    "refers": "“DISEASE-CAUSING NEMATODE” VI",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Ancylostoma) Old World hookworm**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -202,10 +202,10 @@
     "refers": "MICROSCOPIC ECDYSOZOAN",
     "stems": [
       {
-        "BSC": "(to be) an animal identified as **(Tardigrada; numerous genera) tardigrade / \"water bear\"**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
-        "CTE": "(to be) that which gives a particular animal identified as **(Tardigrada; numerous genera) tardigrade / \"water bear\"** its individual identity; the living essence or mental identity of an animal of such kind",
-        "CSV": "(to be) the physical body of an animal identified as **(Tardigrada; numerous genera) tardigrade / \"water bear\"**; the corporeal aspect of an animal of such kind",
-        "OBJ": "(to be) an activity engaged in by an animal identified as **(Tardigrada; numerous genera) tardigrade / \"water bear\"**; what an animal of such kind is doing; to act (as a particular animal species of such kind does)"
+        "BSC": "(to be) an animal identified as **(Tardigrada; numerous genera) tardigrade / “water bear”**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
+        "CTE": "(to be) that which gives a particular animal identified as **(Tardigrada; numerous genera) tardigrade / “water bear”** its individual identity; the living essence or mental identity of an animal of such kind",
+        "CSV": "(to be) the physical body of an animal identified as **(Tardigrada; numerous genera) tardigrade / “water bear”**; the corporeal aspect of an animal of such kind",
+        "OBJ": "(to be) an activity engaged in by an animal identified as **(Tardigrada; numerous genera) tardigrade / “water bear”**; what an animal of such kind is doing; to act (as a particular animal species of such kind does)"
       },
       {
         "BSC": "(to be) an animal identified as **(Loricefera; numerous genera) loriciferan**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -319,7 +319,7 @@
   },
   {
     "root": "LŢTW",
-    "refers": "\"CESTODA (TAPEWORM)\" I",
+    "refers": "“CESTODA (TAPEWORM)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Taenia) taenia, pork tapeworm, beef tapeworm, Asian tapeworm**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -344,7 +344,7 @@
   },
   {
     "root": "LŢTY",
-    "refers": "\"CESTODA (TAPEWORM)\" II",
+    "refers": "“CESTODA (TAPEWORM)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **genus Spirometra) cat tapeworm, dog tapeworm, raccoon tapeworm**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -369,7 +369,7 @@
   },
   {
     "root": "LŢTL",
-    "refers": "\"TREMATODE (FLUKE)\" I",
+    "refers": "“TREMATODE (FLUKE)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Schistosoma) schistosoma / blood fluke**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -394,7 +394,7 @@
   },
   {
     "root": "LŢTR",
-    "refers": "\"TREMATODE (FLUKE)\" II",
+    "refers": "“TREMATODE (FLUKE)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Fasciola) fasciola / common liver fluke**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -468,7 +468,7 @@
   },
   {
     "root": "LŢTĻ",
-    "refers": "\"ANNELID-RELATED ANIMAL\" I",
+    "refers": "“ANNELID-RELATED ANIMAL” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Phoronida; genera Phononis, Actinotrocha) horseshoe worm**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -492,7 +492,7 @@
   },
   {
     "root": "LŢTH",
-    "refers": "\"ANNELID-RELATED ANIMAL\" II",
+    "refers": "“ANNELID-RELATED ANIMAL” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Nemertea; numerous genera) ribbon worm / proboscis worm**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -684,7 +684,7 @@
   },
   {
     "root": "ŢPS",
-    "refers": "\"PTERIOMORPH\" I",
+    "refers": "“PTERIOMORPH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Anomiids; several genera) jingle shell / saddle oyster**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -708,7 +708,7 @@
   },
   {
     "root": "ŢPŠ",
-    "refers": "\"PTERIOMORPH\" II",
+    "refers": "“PTERIOMORPH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Arcids; numerous genera) ark shell / ark clam / bittersweet**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",

--- a/lexicon/7.3.1.8.json
+++ b/lexicon/7.3.1.8.json
@@ -1,7 +1,7 @@
 [
   {
     "root": "KFW",
-    "refers": "\"PORIFERA (SPONGE)\" I",
+    "refers": "“PORIFERA (SPONGE)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Calcarea; numerous genera) calcareous sponge**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -25,7 +25,7 @@
   },
   {
     "root": "KFY",
-    "refers": "\"PORIFERA (SPONGE)\" II",
+    "refers": "“PORIFERA (SPONGE)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Plakinids; several genera) spiculate sponge**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",

--- a/lexicon/7.3.1.9.json
+++ b/lexicon/7.3.1.9.json
@@ -73,7 +73,7 @@
   },
   {
     "root": "ZMW",
-    "refers": "\"AVICULARIOID SPIDER\" I",
+    "refers": "“AVICULARIOID SPIDER” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Actinopodids; genera Actinopus, Missulena, Plesiolena) Actinopod spider, including mouse spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -97,7 +97,7 @@
   },
   {
     "root": "ZMY",
-    "refers": "\"AVICULARIOID SPIDER\" II",
+    "refers": "“AVICULARIOID SPIDER” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Diplurids; numerous genera) curtain-web spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -121,7 +121,7 @@
   },
   {
     "root": "ZML",
-    "refers": "\"AVICULARIOID SPIDER\" III",
+    "refers": "“AVICULARIOID SPIDER” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Ctenizids; genera Cteniza, Cyrtocarenum, Stasimopus) ctenizid / cork-lid trapdoor spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -145,7 +145,7 @@
   },
   {
     "root": "ZMR",
-    "refers": "\"AVICULARIOID SPIDER\" IV",
+    "refers": "“AVICULARIOID SPIDER” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Cyrtaucheniids; numerous genera) wafer trapdoor spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -169,7 +169,7 @@
   },
   {
     "root": "ZNW",
-    "refers": "\"AVICULARIOID SPIDER\" V",
+    "refers": "“AVICULARIOID SPIDER” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Barychelid; numerous genera) barychelid / brushed trapdoor spider / trapdoor baboon spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -193,7 +193,7 @@
   },
   {
     "root": "ZNY",
-    "refers": "\"AVICULARIOID SPIDER\" VI",
+    "refers": "“AVICULARIOID SPIDER” VI",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Therephosids; numerous genera) tarantula**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -217,7 +217,7 @@
   },
   {
     "root": "BZPW",
-    "refers": "\"PRIMITIVE ARANEOMORPHIC SPIDER\" I",
+    "refers": "“PRIMITIVE ARANEOMORPHIC SPIDER” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Hypochilids; genera Ectatosticta, Hypochilus) lampshade spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -241,7 +241,7 @@
   },
   {
     "root": "BZPY",
-    "refers": "\"PRIMITIVE ARANEOMORPHIC SPIDER\" II",
+    "refers": "“PRIMITIVE ARANEOMORPHIC SPIDER” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Gradungulids; several genera) large-clawed spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -265,7 +265,7 @@
   },
   {
     "root": "BZPL",
-    "refers": "\"SYNSPERMIATIC (HAPLOGYNE) SPIDER\" I",
+    "refers": "“SYNSPERMIATIC (HAPLOGYNE) SPIDER” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Diguetiids; genera Diguetia, Segestrioides) coneweb spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -289,7 +289,7 @@
   },
   {
     "root": "BZPR",
-    "refers": "\"SYNSPERMIATIC (HAPLOGYNE) SPIDER\" II",
+    "refers": "“SYNSPERMIATIC (HAPLOGYNE) SPIDER” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Tetrablemmids; numerous genera) armoured spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -313,7 +313,7 @@
   },
   {
     "root": "BZPŘ",
-    "refers": "\"SYNSPERMIATIC (HAPLOGYNE) SPIDER\" III",
+    "refers": "“SYNSPERMIATIC (HAPLOGYNE) SPIDER” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Dysderids; numerous genera) woodlouse hunter / cell spider / sowbug-eating spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -337,7 +337,7 @@
   },
   {
     "root": "BZPF",
-    "refers": "\"SYNSPERMIATIC (HAPLOGYNE) SPIDER\" IV",
+    "refers": "“SYNSPERMIATIC (HAPLOGYNE) SPIDER” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Oonopids; numerous genera) goblin spider / dwarf hunting spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -361,7 +361,7 @@
   },
   {
     "root": "BZPĻ",
-    "refers": "\"SYNSPERMIATIC (HAPLOGYNE) SPIDER\" V",
+    "refers": "“SYNSPERMIATIC (HAPLOGYNE) SPIDER” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Sicariids; genera Loxosceles, Hexophthalma, Sicarius) recluse spider, violin spider, sand spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -385,7 +385,7 @@
   },
   {
     "root": "BZPÇ",
-    "refers": "\"SYNSPERMIATIC (HAPLOGYNE) SPIDER\" VI",
+    "refers": "“SYNSPERMIATIC (HAPLOGYNE) SPIDER” VI",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Scytodids; several genera) spitting spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -409,7 +409,7 @@
   },
   {
     "root": "BZPH",
-    "refers": "\"PALPIMANOID SPIDER\" I",
+    "refers": "“PALPIMANOID SPIDER” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Archaeids; several genera) assassin spider / pelican spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -433,7 +433,7 @@
   },
   {
     "root": "BZPHW",
-    "refers": "\"PALPIMANOID SPIDER\" II",
+    "refers": "“PALPIMANOID SPIDER” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Mecysmaucheniids; several genera) mecysmaucheniid spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -457,7 +457,7 @@
   },
   {
     "root": "SPW",
-    "refers": "\"ENTELEGYNE SPIDER\" I",
+    "refers": "“ENTELEGYNE SPIDER” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Theridiids; numerous genera) tangle-web spider / cobweb spider / comb-footed spider, common house spider, widow**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -481,7 +481,7 @@
   },
   {
     "root": "SPY",
-    "refers": "\"ENTELEGYNE SPIDER\" II",
+    "refers": "“ENTELEGYNE SPIDER” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Mysmenids; numerous genera) spurred orb-weaver spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -505,7 +505,7 @@
   },
   {
     "root": "SPŘ",
-    "refers": "\"ENTELEGYNE SPIDER\" III",
+    "refers": "“ENTELEGYNE SPIDER” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Anapids; numerous genera) anapid spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -529,7 +529,7 @@
   },
   {
     "root": "SPF",
-    "refers": "\"ENTELEGYNE SPIDER\" IV",
+    "refers": "“ENTELEGYNE SPIDER” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Theridiosomatids; numerous genera) ray spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -553,7 +553,7 @@
   },
   {
     "root": "SPŢ",
-    "refers": "\"ENTELEGYNE SPIDER\" V",
+    "refers": "“ENTELEGYNE SPIDER” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Synaphrids; several genera) synaphrid spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -577,7 +577,7 @@
   },
   {
     "root": "SPV",
-    "refers": "\"ENTELEGYNE SPIDER\" VI",
+    "refers": "“ENTELEGYNE SPIDER” VI",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Agelenids; numerous genera) funnel weaver spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -601,7 +601,7 @@
   },
   {
     "root": "SPĻ",
-    "refers": "\"ENTELEGYNE SPIDER\" VII",
+    "refers": "“ENTELEGYNE SPIDER” VII",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Corinnids; numerous genera) corinnid sac spider / dark sac spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -625,7 +625,7 @@
   },
   {
     "root": "SPÇ",
-    "refers": "\"ENTELEGYNE SPIDER\" VIII",
+    "refers": "“ENTELEGYNE SPIDER” VIII",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Gnaphosids; numerous genera) ground spider / flat-bellied ground spider / long-spinneret ground spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -649,7 +649,7 @@
   },
   {
     "root": "SPH",
-    "refers": "\"ENTELEGYNE SPIDER\" IX",
+    "refers": "“ENTELEGYNE SPIDER” IX",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Ammoxenids; several genera) termite hunter spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -673,7 +673,7 @@
   },
   {
     "root": "SPFW",
-    "refers": "\"ENTELEGYNE SPIDER\" X",
+    "refers": "“ENTELEGYNE SPIDER” X",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Salticids; numerous genera) jumping spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -697,7 +697,7 @@
   },
   {
     "root": "SPFY",
-    "refers": "\"ENTELEGYNE SPIDER\" XI",
+    "refers": "“ENTELEGYNE SPIDER” XI",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Thomisids; numerous genera) crab spider, flower spider / flower crab spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -721,7 +721,7 @@
   },
   {
     "root": "SPFL",
-    "refers": "\"ENTELEGYNE SPIDER\" XII",
+    "refers": "“ENTELEGYNE SPIDER” XII",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Desids; numerous genera) intertidal spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -745,7 +745,7 @@
   },
   {
     "root": "SPFR",
-    "refers": "\"ENTELEGYNE SPIDER\" XIII",
+    "refers": "“ENTELEGYNE SPIDER” XIII",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Dictynids; numerous genera) dictynid spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -769,7 +769,7 @@
   },
   {
     "root": "SPFŘ",
-    "refers": "\"ENTELEGYNE SPIDER\" XIV",
+    "refers": "“ENTELEGYNE SPIDER” XIV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Eresids; numerous genera) velvet spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -793,7 +793,7 @@
   },
   {
     "root": "SPHW",
-    "refers": "\"ENTELEGYNE SPIDER\" XV",
+    "refers": "“ENTELEGYNE SPIDER” XV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Lycosids; numerous genera) wolf spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -817,7 +817,7 @@
   },
   {
     "root": "SPÇW",
-    "refers": "\"ENTELEGYNE SPIDER\" XVI",
+    "refers": "“ENTELEGYNE SPIDER” XVI",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Oxyopids; several genera) lynx spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -841,7 +841,7 @@
   },
   {
     "root": "SPÇÇ",
-    "refers": "\"ENTELEGYNE SPIDER\" XVII",
+    "refers": "“ENTELEGYNE SPIDER” XVII",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Psechrids; genera Fecenia, Psechrus) psechrid spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -865,7 +865,7 @@
   },
   {
     "root": "SPŢW",
-    "refers": "\"ENTELEGYNE SPIDER\" XVIII",
+    "refers": "“ENTELEGYNE SPIDER” XVIII",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Zoropsids; numerous genera) false wolf spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -889,7 +889,7 @@
   },
   {
     "root": "SPŢY",
-    "refers": "\"ENTELEGYNE SPIDER\" XIX",
+    "refers": "“ENTELEGYNE SPIDER” XIX",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Malkarids; numerous genera) shield spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -913,7 +913,7 @@
   },
   {
     "root": "SPŢL",
-    "refers": "\"ENTELEGYNE SPIDER\" XX",
+    "refers": "“ENTELEGYNE SPIDER” XX",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Phyxelidids; numerous genera) lace web spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -937,7 +937,7 @@
   },
   {
     "root": "SPŢR",
-    "refers": "\"ENTELEGYNE SPIDER\" XXI",
+    "refers": "“ENTELEGYNE SPIDER” XXI",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Uloborids; numerous genera) hackled orb weaver**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -961,7 +961,7 @@
   },
   {
     "root": "SPŢŘ",
-    "refers": "\"ENTELEGYNE SPIDER\" XXII",
+    "refers": "“ENTELEGYNE SPIDER” XXII",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Miturgids; numerous genera) long-legged sac spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -985,7 +985,7 @@
   },
   {
     "root": "SPĻW",
-    "refers": "\"ENTELEGYNE SPIDER\" XXIII",
+    "refers": "“ENTELEGYNE SPIDER” XXIII",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Cycloctenids; several genera) cycloctenid spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1009,7 +1009,7 @@
   },
   {
     "root": "GGZ",
-    "refers": "\"SCORPION\" I",
+    "refers": "“SCORPION” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Buthida; numerous genera) thick-tailed scorpion, fat-tailed scorpion, bark scorpion**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1033,7 +1033,7 @@
   },
   {
     "root": "GGV",
-    "refers": "\"SCORPION\" II",
+    "refers": "“SCORPION” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Scorpionidae; numerous genera) giant forest scorpion, emperor scorpion, burrowing scorpion / hissing scorpion / serkets, pale-legged scorpion**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1057,7 +1057,7 @@
   },
   {
     "root": "GGḐ",
-    "refers": "\"SCORPION\" III",
+    "refers": "“SCORPION” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Pseudochactida; three genera) pseudochactid cave-dwelling scorpion**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1130,7 +1130,7 @@
   },
   {
     "root": "ẒFL",
-    "refers": "\"PARASITIC MITE\" I",
+    "refers": "“PARASITIC MITE” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Sarcoptes) itch mite / scabies mite**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1155,7 +1155,7 @@
   },
   {
     "root": "ẒFR",
-    "refers": "\"PARASITIC MITE\" II",
+    "refers": "“PARASITIC MITE” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Dermanyssus) red mite**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1180,7 +1180,7 @@
   },
   {
     "root": "ẒFŘ",
-    "refers": "\"PARASITIC MITE\" III",
+    "refers": "“PARASITIC MITE” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Cheyletus) cheyletus mite**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1205,7 +1205,7 @@
   },
   {
     "root": "ẒFM",
-    "refers": "\"PARASITIC MITE\" IV",
+    "refers": "“PARASITIC MITE” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Acarus) flour mite**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1230,7 +1230,7 @@
   },
   {
     "root": "ẒFN",
-    "refers": "\"PARASITIC MITE\" V",
+    "refers": "“PARASITIC MITE” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Liponyssoides) house rat mite**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1279,7 +1279,7 @@
   },
   {
     "root": "ẒNW",
-    "refers": "\"OTHER ARACHNID\" I",
+    "refers": "“OTHER ARACHNID” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Opiliones; numerous genera) harvestman / harvester / shepherd spider**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1303,7 +1303,7 @@
   },
   {
     "root": "ẒNY",
-    "refers": "\"OTHER ARACHNID\" II",
+    "refers": "“OTHER ARACHNID” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Amblypygids; numerous genera) whip spider / tailless whip scorpion**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1327,7 +1327,7 @@
   },
   {
     "root": "ẒŇW",
-    "refers": "\"OTHER ARACHNID\" III",
+    "refers": "“OTHER ARACHNID” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Palpigradids; numerous genera) palpigrade / microwhip scorpion**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1375,7 +1375,7 @@
   },
   {
     "root": "KŢKW",
-    "refers": "\"BRANCHIOPOD\" I",
+    "refers": "“BRANCHIOPOD” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Anostraca; numerous genera) fairy shrimp, brine shrimp**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1399,7 +1399,7 @@
   },
   {
     "root": "KŢKY",
-    "refers": "\"BRANCHIOPOD\" II (CLAM SHRIMP)",
+    "refers": "“BRANCHIOPOD” II (CLAM SHRIMP)",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Laevicaudata; genera Lynceiopsis, Lynceus, Paralimnetes) [laevidaudate] clam shrimp**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1567,7 +1567,7 @@
   },
   {
     "root": "KŢNW",
-    "refers": "\"PERACARID (BROOD-POUCH BEARING SHRIMP)\" I",
+    "refers": "“PERACARID (BROOD-POUCH BEARING SHRIMP)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Cumacea; numerous genera) hooded shrimp / comma shrimp**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1591,7 +1591,7 @@
   },
   {
     "root": "KŢNY",
-    "refers": "\"PERACARID (BROOD-POUCH BEARING SHRIMP)\" II",
+    "refers": "“PERACARID (BROOD-POUCH BEARING SHRIMP)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Mictacea, Lophogastrids; several genera) mictacean or lophogastrid crustacean**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1663,7 +1663,7 @@
   },
   {
     "root": "KŢPL",
-    "refers": "\"CARIDEAN SHRIMP\" I",
+    "refers": "“CARIDEAN SHRIMP” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Alpheoids; numerous genera) snapping shrimp / pistol shrimp / alpheid shrimp, cleaner shrimp, broken-back shrimp / anemone shrimp**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1687,7 +1687,7 @@
   },
   {
     "root": "KŢPR",
-    "refers": "\"CARIDEAN SHRIMP\" II",
+    "refers": "“CARIDEAN SHRIMP” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Atyids; numerous genera) atyid shrimp**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1711,7 +1711,7 @@
   },
   {
     "root": "KŢPŘ",
-    "refers": "\"CARIDEAN SHRIMP\" III",
+    "refers": "“CARIDEAN SHRIMP” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Nematocarcinoids; several genera) nematocarcinoid shrimp**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1735,7 +1735,7 @@
   },
   {
     "root": "KŢPH",
-    "refers": "\"CARIDEAN SHRIMP\" IV",
+    "refers": "“CARIDEAN SHRIMP” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Stylodactyloids; several genera) stylodactyloid shrimp**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1903,7 +1903,7 @@
   },
   {
     "root": "KŢŢW",
-    "refers": "\"CRAB-LIKE CREATURE\" I",
+    "refers": "“CRAB-LIKE CREATURE” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Paguroids; numerous genera) hermit crab, coconut crab / robber crab**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -1927,7 +1927,7 @@
   },
   {
     "root": "KŢŢY",
-    "refers": "\"CRAB-LIKE CREATURE\" II",
+    "refers": "“CRAB-LIKE CREATURE” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Galatheoids, Chirostyloids; numerous genera ) squat lobster, porcelain crab**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2239,7 +2239,7 @@
   },
   {
     "root": "XFY",
-    "refers": "\"CRICKET-LIKE CREATURE\" I",
+    "refers": "“CRICKET-LIKE CREATURE” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Tettigoniids; numerous genera) katydid / bush cricket**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2263,7 +2263,7 @@
   },
   {
     "root": "XFL",
-    "refers": "\"CRICKET-LIKE CREATURE\" II",
+    "refers": "“CRICKET-LIKE CREATURE” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Anostostomatids; numerous genera) weta [except cave weta] / king cricket**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2287,7 +2287,7 @@
   },
   {
     "root": "XFR",
-    "refers": "\"CRICKET-LIKE CREATURE\" III",
+    "refers": "“CRICKET-LIKE CREATURE” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Rhaphidophorids; numerous genera) cave weta / cave cricket, camleback cricket / camel cricket, spider cricket, sand treader**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2600,7 +2600,7 @@
   },
   {
     "root": "NĻTW",
-    "refers": "\"REDUVIID (ASSASSIN BUG)\" I",
+    "refers": "“REDUVIID (ASSASSIN BUG)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Triatomines; numerous genera) kissing bug / conenose bug / cone-headed bug / vampire bug**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2624,7 +2624,7 @@
   },
   {
     "root": "NĻTY",
-    "refers": "\"REDUVIID (ASSASSIN BUG)\" II",
+    "refers": "“REDUVIID (ASSASSIN BUG)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Phymatines; numerous genera) ambush bug**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2648,7 +2648,7 @@
   },
   {
     "root": "NĻTL",
-    "refers": "\"PENTATOMOMORPHIC BUG\" I",
+    "refers": "“PENTATOMOMORPHIC BUG” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Pentatomoids; numerous genera) shield bug, stink bug, burrowing bug, jewel bug, ebony bug, chust bug, giant shield bug**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2672,7 +2672,7 @@
   },
   {
     "root": "NĻTR",
-    "refers": "\"PENTATOMOMORPHIC BUG\" II",
+    "refers": "“PENTATOMOMORPHIC BUG” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Hyocephalids; genera Hyocephalus, Maevius) hyocephalid bug**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2768,7 +2768,7 @@
   },
   {
     "root": "NĻC",
-    "refers": "\"CIMICOMORPHIC BUG\" I",
+    "refers": "“CIMICOMORPHIC BUG” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Cimicids; numerous genera) cimicid, bed bug**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2793,7 +2793,7 @@
   },
   {
     "root": "NĻCW",
-    "refers": "\"CIMICOMORPHIC BUG\" II",
+    "refers": "“CIMICOMORPHIC BUG” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Mirids; numerous genera) capsid bug / mirid bug / plant bug / leaf bug / grass bug, lygus bug, apple dimpling bug, mosquito bug, honelylocust plant bug, green mind, potato mind**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2817,7 +2817,7 @@
   },
   {
     "root": "NĻČ",
-    "refers": "\"CIMICOMORPHIC BUG\" III",
+    "refers": "“CIMICOMORPHIC BUG” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Tingids; numerous genera) lace bug**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2841,7 +2841,7 @@
   },
   {
     "root": "NĻČW",
-    "refers": "\"CIMICOMORPHIC BUG\" IV",
+    "refers": "“CIMICOMORPHIC BUG” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Velocipedids; several genera) velocipedid bug**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2865,7 +2865,7 @@
   },
   {
     "root": "NĻTV",
-    "refers": "\"CIMICOMORPHIC BUG\" V",
+    "refers": "“CIMICOMORPHIC BUG” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Plokiophilids; several genera) plokiophilid bug**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2961,7 +2961,7 @@
   },
   {
     "root": "NĻFL",
-    "refers": "\"NEPOMORPHIC BUG\" I",
+    "refers": "“NEPOMORPHIC BUG” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Belostomatids; numerous genera) giant water bug / toe-biter / electric-light bug / alligator tick / alligator flea**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -2985,7 +2985,7 @@
   },
   {
     "root": "NĻFR",
-    "refers": "\"NEPOMORPHIC BUG\" II",
+    "refers": "“NEPOMORPHIC BUG” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Gelastocorids; genera Gelastocoris, Nerthra) toad bug**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3009,7 +3009,7 @@
   },
   {
     "root": "NĻFŘ",
-    "refers": "\"NEPOMORPHIC BUG\" III",
+    "refers": "“NEPOMORPHIC BUG” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Notonectids and Pleoids; numerous genera) backswimmer, pygmy backswimmer**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3297,7 +3297,7 @@
   },
   {
     "root": "BZZŇ",
-    "refers": "\"CHRYSIDOID / VESPOID WASP\" I",
+    "refers": "“CHRYSIDOID / VESPOID WASP” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Chrysidids; numerous genera) cuckoo wasp, emerald wasp, jewel wasp, gold wasp, ruby wasp**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3321,7 +3321,7 @@
   },
   {
     "root": "BZZḐ",
-    "refers": "\"CHRYSIDOID / VESPOID WASP\" II",
+    "refers": "“CHRYSIDOID / VESPOID WASP” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Mutillids; numerous genera) velvet wasp / velvet ant**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3369,7 +3369,7 @@
   },
   {
     "root": "BZZD",
-    "refers": "\"PARASITOID [NON-ACULEATE] WASP\" I",
+    "refers": "“PARASITOID [NON-ACULEATE] WASP” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Mymarids; numerous genera) fairy wasp / fairyfly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3393,7 +3393,7 @@
   },
   {
     "root": "BZZG",
-    "refers": "\"PARASITOID [NON-ACULEATE] WASP\" II",
+    "refers": "“PARASITOID [NON-ACULEATE] WASP” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Cynipids; numerous genera) gall wasp / gallfly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3417,7 +3417,7 @@
   },
   {
     "root": "BZZP",
-    "refers": "\"PARASITOID [NON-ACULEATE] WASP\" III",
+    "refers": "“PARASITOID [NON-ACULEATE] WASP” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Evaniids; numerous genera) ensign wasp / nightshade wasp / hatchet wasp**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3441,7 +3441,7 @@
   },
   {
     "root": "BZZT",
-    "refers": "\"PARASITOID [NON-ACULEATE] WASP\" IV",
+    "refers": "“PARASITOID [NON-ACULEATE] WASP” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Ichneumonids; numerous genera) ichneumon wasp, scorpion wasp**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3465,7 +3465,7 @@
   },
   {
     "root": "BZZK",
-    "refers": "\"PARASITOID [NON-ACULEATE] WASP\" V",
+    "refers": "“PARASITOID [NON-ACULEATE] WASP” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Sephanids; several genera) crown wasp**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3489,7 +3489,7 @@
   },
   {
     "root": "MŢK",
-    "refers": "\"FORMICINE ANT\" I",
+    "refers": "“FORMICINE ANT” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Formica) wood ant, mound ant, thatching ant, field ant , meadow ant, horse ant**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3513,7 +3513,7 @@
   },
   {
     "root": "MŢKW",
-    "refers": "\"FORMICINE ANT\" II",
+    "refers": "“FORMICINE ANT” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Camponotus) carpenter ant**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3537,7 +3537,7 @@
   },
   {
     "root": "MŢKY",
-    "refers": "\"FORMICINE ANT\" III",
+    "refers": "“FORMICINE ANT” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Brachymyrmex) rover ant**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3561,7 +3561,7 @@
   },
   {
     "root": "MŢKL",
-    "refers": "\"MYRMICINE ANT\" I",
+    "refers": "“MYRMICINE ANT” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Solenopsis) fire ant, ginger ant, tropical fire ant**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3585,7 +3585,7 @@
   },
   {
     "root": "MŢKR",
-    "refers": "\"MYRMICINE ANT\" II",
+    "refers": "“MYRMICINE ANT” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Cremtogaster) Saint Valentine ant / cocktail ant / acrobat ant**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3633,7 +3633,7 @@
   },
   {
     "root": "MŢKF",
-    "refers": "\"DOLICHODERINE ANT\" I",
+    "refers": "“DOLICHODERINE ANT” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Linepithema) Argentine ant**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3657,7 +3657,7 @@
   },
   {
     "root": "MŢKŢ",
-    "refers": "\"DOLICHODERINE ANT\" II",
+    "refers": "“DOLICHODERINE ANT” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Tapinoma erraticum) erratic ant**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3705,7 +3705,7 @@
   },
   {
     "root": "ZZVW",
-    "refers": "\"SYMPHYTE (SAWFLY)\" I",
+    "refers": "“SYMPHYTE (SAWFLY)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Tenthredinids; numerous genera) common sawfly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3729,7 +3729,7 @@
   },
   {
     "root": "ZZVY",
-    "refers": "\"SYMPHYTE (SAWFLY)\" II",
+    "refers": "“SYMPHYTE (SAWFLY)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Xyelids; several genera) xyelid sawfly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3753,7 +3753,7 @@
   },
   {
     "root": "ZZVL",
-    "refers": "\"SYMPHYTE (SAWFLY)\" III",
+    "refers": "“SYMPHYTE (SAWFLY)” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Cephoids; numerous genera) stem sawfly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3849,7 +3849,7 @@
   },
   {
     "root": "ẒBW",
-    "refers": "\"NEUROPTERID (LACEWING)\" I",
+    "refers": "“NEUROPTERID (LACEWING)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Osmylids; numerous genera) giant lacewing**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3873,7 +3873,7 @@
   },
   {
     "root": "ẒBY",
-    "refers": "\"NEUROPTERID (LACEWING)\" II",
+    "refers": "“NEUROPTERID (LACEWING)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Hemerobiids; numerous genera) brown lacewing**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3897,7 +3897,7 @@
   },
   {
     "root": "ẒBL",
-    "refers": "\"NEUROPTERID (LACEWING)\" III",
+    "refers": "“NEUROPTERID (LACEWING)” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Mantispids; numerous genera) mantidfly / mantisfly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3921,7 +3921,7 @@
   },
   {
     "root": "ẒBR",
-    "refers": "\"NEUROPTERID (LACEWING)\" IV",
+    "refers": "“NEUROPTERID (LACEWING)” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Nymphids; several genera) split-footed lacewing**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3945,7 +3945,7 @@
   },
   {
     "root": "ẒBŘ",
-    "refers": "\"NEUROPTERID (LACEWING)\" V",
+    "refers": "“NEUROPTERID (LACEWING)” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Psychopsids; several genera) silky lacewing**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3969,7 +3969,7 @@
   },
   {
     "root": "FBW",
-    "refers": "\"ADEGPHAGAN BEETLE\" I",
+    "refers": "“ADEGPHAGAN BEETLE” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Carabids; numerous genera) ground beetle, bombardier beetle, ant nest beetle / paussine, sand beetle, tiger beetle, harp beetle, violin beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -3993,7 +3993,7 @@
   },
   {
     "root": "FBY",
-    "refers": "\"ADEGPHAGAN BEETLE\" II",
+    "refers": "“ADEGPHAGAN BEETLE” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Dystiscids; numerous genera) predacious diving beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4017,7 +4017,7 @@
   },
   {
     "root": "FBL",
-    "refers": "\"ADEGPHAGAN BEETLE\" III",
+    "refers": "“ADEGPHAGAN BEETLE” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Amphizoans; genus Amphizoa) troutstream beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4041,7 +4041,7 @@
   },
   {
     "root": "FBR",
-    "refers": "\"ADEGPHAGAN BEETLE\" IV",
+    "refers": "“ADEGPHAGAN BEETLE” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Aspidytids; genus Aspidytes) aspidytes beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4065,7 +4065,7 @@
   },
   {
     "root": "RÇK",
-    "refers": "\"CUCUJOID BEETLE\" I",
+    "refers": "“CUCUJOID BEETLE” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Coccinelids; numerous genera) ladybug / ladybird / lady beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4089,7 +4089,7 @@
   },
   {
     "root": "RÇKW",
-    "refers": "\"CUCUJOID BEETLE\" II",
+    "refers": "“CUCUJOID BEETLE” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Endomychids; numerous genera) handsome fungus beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4113,7 +4113,7 @@
   },
   {
     "root": "RÇKY",
-    "refers": "\"CUCUJOID BEETLE\" III",
+    "refers": "“CUCUJOID BEETLE” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Cucujids; several genera) flat bark beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4137,7 +4137,7 @@
   },
   {
     "root": "RÇKL",
-    "refers": "\"CUCUJOID BEETLE\" IV",
+    "refers": "“CUCUJOID BEETLE” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Sylvanids; numerous genera) sylvan flat bark beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4161,7 +4161,7 @@
   },
   {
     "root": "RÇKR",
-    "refers": "\"CUCUJOID BEETLE\" V",
+    "refers": "“CUCUJOID BEETLE” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Nitidulids; numerous genera) sap beetle, picnic beetle / beer bug, small hive beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4185,7 +4185,7 @@
   },
   {
     "root": "RÇKŘ",
-    "refers": "\"CUCUJOID BEETLE\" VI",
+    "refers": "“CUCUJOID BEETLE” VI",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Monotomids; numerous genera) root-eating beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4209,7 +4209,7 @@
   },
   {
     "root": "RÇKÇ",
-    "refers": "\"CUCUJOID BEETLE\" VII",
+    "refers": "“CUCUJOID BEETLE” VII",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Sphindids; several genera) cryptic slime mold beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4281,7 +4281,7 @@
   },
   {
     "root": "RÇKH",
-    "refers": "\"CLEROID BEETLE\" I",
+    "refers": "“CLEROID BEETLE” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Clerids; numerous genera) checkered beetle, ant beetle, steely blue beetle, ham beetle, yellow-horned clerid**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4305,7 +4305,7 @@
   },
   {
     "root": "RÇKHW",
-    "refers": "\"CLEROID BEETLE\" II",
+    "refers": "“CLEROID BEETLE” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Byturids; several genera) fruitworm beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4353,7 +4353,7 @@
   },
   {
     "root": "RÇG",
-    "refers": "\"TENEBRIONOID BEETLE\" I",
+    "refers": "“TENEBRIONOID BEETLE” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Aderids; numerous genera) ant-like leaf beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4377,7 +4377,7 @@
   },
   {
     "root": "RÇGW",
-    "refers": "\"TENEBRIONOID BEETLE\" II",
+    "refers": "“TENEBRIONOID BEETLE” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Mordellids; numerous genera) tumbling flower beetle / pintail beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4401,7 +4401,7 @@
   },
   {
     "root": "RÇGY",
-    "refers": "\"TENEBRIONOID BEETLE\" III",
+    "refers": "“TENEBRIONOID BEETLE” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Zopherids other than Colydiines; several genera) ironclad beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4425,7 +4425,7 @@
   },
   {
     "root": "RÇGL",
-    "refers": "\"TENEBRIONOID BEETLE\" IV",
+    "refers": "“TENEBRIONOID BEETLE” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Meloids; numerous genera) blister beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4449,7 +4449,7 @@
   },
   {
     "root": "RÇGR",
-    "refers": "\"TENEBRIONOID BEETLE\" V",
+    "refers": "“TENEBRIONOID BEETLE” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Stenotrachelids; several genera) false long-horned beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4473,7 +4473,7 @@
   },
   {
     "root": "RÇGŘ",
-    "refers": "\"TENEBRIONOID BEETLE\" VI",
+    "refers": "“TENEBRIONOID BEETLE” VI",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Tenebrionids; numerous genera) darkling beetle, flour beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4497,7 +4497,7 @@
   },
   {
     "root": "RBK",
-    "refers": "\"SCARABAEID (SCARAB) BEETLE\" I",
+    "refers": "“SCARABAEID (SCARAB) BEETLE” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Scarabaeines; numerous genera) true dung beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4521,7 +4521,7 @@
   },
   {
     "root": "RBKW",
-    "refers": "\"SCARABAEID (SCARAB) BEETLE\" II",
+    "refers": "“SCARABAEID (SCARAB) BEETLE” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Dynastines; numerous genera) rhinoceros beetle / unicorn beetle / horn beetle, Atlas beetle, Hercules beetle, Neptune beetle, Caucasus beetle, rabbit beetle, Siamese beetle, Mars beetle, elephant beetle, actaeon beetle, ox beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4545,7 +4545,7 @@
   },
   {
     "root": "RBKY",
-    "refers": "\"SCARABAEID (SCARAB) BEETLE\" III",
+    "refers": "“SCARABAEID (SCARAB) BEETLE” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Euchirines; several genera) long-armed scarab**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4569,7 +4569,7 @@
   },
   {
     "root": "RBKL",
-    "refers": "\"SCARABAEOID BEETLE\" I",
+    "refers": "“SCARABAEOID BEETLE” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Hybosorids; numerous genera) scavenger scarab beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4593,7 +4593,7 @@
   },
   {
     "root": "RBKR",
-    "refers": "\"SCARABAEOID BEETLE\" II",
+    "refers": "“SCARABAEOID BEETLE” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Lucanids; numerous genera) stag beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4617,7 +4617,7 @@
   },
   {
     "root": "RBKŘ",
-    "refers": "\"SCARABAEOID BEETLE\" III",
+    "refers": "“SCARABAEOID BEETLE” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Pleocomids; genus Pleocoma) rain beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4641,7 +4641,7 @@
   },
   {
     "root": "RBKÇ",
-    "refers": "\"SCARABAEOID BEETLE\" IV",
+    "refers": "“SCARABAEOID BEETLE” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Geotrupids; numerous genera) earth-boring dung beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4665,7 +4665,7 @@
   },
   {
     "root": "RBKF",
-    "refers": "\"STAPHYLINOID BEETLE\" I",
+    "refers": "“STAPHYLINOID BEETLE” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Silphids; numerous genera) carrion beetle / burying beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4689,7 +4689,7 @@
   },
   {
     "root": "RBKV",
-    "refers": "\"STAPHYLINOID BEETLE\" II",
+    "refers": "“STAPHYLINOID BEETLE” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Leiodids; numerous genera) round fungus beetle, mammal-nest beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4737,7 +4737,7 @@
   },
   {
     "root": "RBD",
-    "refers": "\"ELATEROID BEETLE\" I",
+    "refers": "“ELATEROID BEETLE” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Elaterids; numerous genera) click beetle / snapping beetle / spring beetle / elater / skipjack, false firefly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4761,7 +4761,7 @@
   },
   {
     "root": "RBDW",
-    "refers": "\"ELATEROID BEETLE\" II",
+    "refers": "“ELATEROID BEETLE” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Cantharids; numerous genera) soldier beetle / leatherwing**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4785,7 +4785,7 @@
   },
   {
     "root": "RBDY",
-    "refers": "\"ELATEROID BEETLE\" III",
+    "refers": "“ELATEROID BEETLE” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Lampyrids; numerous genera) firefly / lightning bug**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4809,7 +4809,7 @@
   },
   {
     "root": "RBDL",
-    "refers": "\"ELATEROID BEETLE\" IV",
+    "refers": "“ELATEROID BEETLE” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Brachypsectrids; genus Brachypsectra) Texas beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4905,7 +4905,7 @@
   },
   {
     "root": "RBC",
-    "refers": "\"BYRRHOID BEETLE\" I",
+    "refers": "“BYRRHOID BEETLE” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Byrrhids; numerous genera) pill beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4929,7 +4929,7 @@
   },
   {
     "root": "RBČ",
-    "refers": "\"BYRRHOID BEETLE\" II",
+    "refers": "“BYRRHOID BEETLE” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Limnichids; numerous genera) minute mud beetle / minute marsh-loving beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4953,7 +4953,7 @@
   },
   {
     "root": "RBẒ",
-    "refers": "\"BYRRHOID BEETLE\" III",
+    "refers": "“BYRRHOID BEETLE” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Eulichadids; several genera) forest stream beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -4977,7 +4977,7 @@
   },
   {
     "root": "RBJ",
-    "refers": "\"BYRRHOID BEETLE\" IV",
+    "refers": "“BYRRHOID BEETLE” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Ptilodactylids; several genera) toe-winged beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5001,7 +5001,7 @@
   },
   {
     "root": "RBVM",
-    "refers": "\"BOSTRICHIFORM BEETLE\" I",
+    "refers": "“BOSTRICHIFORM BEETLE” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Bostrichids; numerous genera) horned powderpost beetle, false powderpost beetle, auger beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5025,7 +5025,7 @@
   },
   {
     "root": "RBVN",
-    "refers": "\"BOSTRICHIFORM BEETLE\" II",
+    "refers": "“BOSTRICHIFORM BEETLE” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Endecatomids; genus Endecatomus) endecatomus beetle**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5073,7 +5073,7 @@
   },
   {
     "root": "LSP",
-    "refers": "\"PRIMITIVE MOTH\" I",
+    "refers": "“PRIMITIVE MOTH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Aglossata [Agathiphagids]; genus Agathiphaga) kauri moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5097,7 +5097,7 @@
   },
   {
     "root": "LSPW",
-    "refers": "\"PRIMITIVE MOTH\" II",
+    "refers": "“PRIMITIVE MOTH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Dacnonypha [Eriocraniids]; several genera) eriocraniid metallic moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5121,7 +5121,7 @@
   },
   {
     "root": "LSPY",
-    "refers": "\"PRIMITIVE MOTH\" III",
+    "refers": "“PRIMITIVE MOTH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Neopseustids; several genera) archaic bell moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5289,7 +5289,7 @@
   },
   {
     "root": "LSPÇ",
-    "refers": "\"YPONOMEUTOID MOTH\" I",
+    "refers": "“YPONOMEUTOID MOTH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Yponomeutids; numerous genera) ermine moth,**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5313,7 +5313,7 @@
   },
   {
     "root": "LSPH",
-    "refers": "\"YPONOMEUTOID MOTH\" II",
+    "refers": "“YPONOMEUTOID MOTH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Plutellids; numerous genera) diamondback moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5337,7 +5337,7 @@
   },
   {
     "root": "LSPÇW",
-    "refers": "\"YPONOMEUTOID MOTH\" III",
+    "refers": "“YPONOMEUTOID MOTH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Heliodinids; numerous genera) sun moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5361,7 +5361,7 @@
   },
   {
     "root": "LSPHW",
-    "refers": "\"YPONOMEUTOID MOTH\" IV",
+    "refers": "“YPONOMEUTOID MOTH” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Ypsolophids seveal genera) ypsolophid moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5409,7 +5409,7 @@
   },
   {
     "root": "LFPW",
-    "refers": "\"TORTRICID (a.k.a. TORTRIX or LEAFROLLER) MOTH\" I",
+    "refers": "“TORTRICID (a.k.a. TORTRIX or LEAFROLLER) MOTH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Tortricids; numerous genera) leafroller moth / tortrix moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5433,7 +5433,7 @@
   },
   {
     "root": "LFPY",
-    "refers": "\"TORTRICID (a.k.a. TORTRIX or LEAFROLLER) MOTH\" II",
+    "refers": "“TORTRICID (a.k.a. TORTRIX or LEAFROLLER) MOTH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Archips) fruit-tree leafroller moth, ugly-nest caterpillar moth, brown oak tortrix, oak webworm moth, baldcypress leafroller, black shield leafroller / gray archips moth, larger boxelder leafroller, large fruit tree tortrix, rose tortrix / rose leaf roller, oak leafroller, apple leafroller, variegated golden tortrix, striated tortrix moth / striated leafroller, southern ugly-nest caterpillar moth, spring spruce needle moth / spruce needleworm moth, omnivorous leafroller, dusky-back leafroller, smoked leafroller / hickory webworm moth, Georgia archips moth, exotic leafroller moth / apple tortrix, boldly-marked archips moth, Asiatic leafroller, groundnut leafroller**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5457,7 +5457,7 @@
   },
   {
     "root": "LFPL",
-    "refers": "\"TORTRICID (a.k.a. TORTRIX or LEAFROLLER) MOTH\" III",
+    "refers": "“TORTRICID (a.k.a. TORTRIX or LEAFROLLER) MOTH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Choristoneura) broken-banded leafroller /dark-banded fireworm moth, large aspen tortrix, two-year cycle budworm moth, spruce budworm moth, western spruce budworm moth, eastern spruce budworm moth, mountain-ash tortricid, strawberry leafroller, sugar pine tortrix, parallel-banded leafroller moth, jack pine budworm moth, oblique banded leaf roller / rosaceous leaf roller, zapulata moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5481,7 +5481,7 @@
   },
   {
     "root": "LFPR",
-    "refers": "\"TORTRICID (a.k.a. TORTRIX or LEAFROLLER) MOTH\" IV",
+    "refers": "“TORTRICID (a.k.a. TORTRIX or LEAFROLLER) MOTH” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Spilonata) bud moth, white fruit moth / larger apple fruit moth / eye-spotted bud moth, larch leafroller, apple fruit licker**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5505,7 +5505,7 @@
   },
   {
     "root": "LFPŘ",
-    "refers": "\"TORTRICID (a.k.a. TORTRIX or LEAFROLLER) MOTH\" V",
+    "refers": "“TORTRICID (a.k.a. TORTRIX or LEAFROLLER) MOTH” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Adoxophyes) appleleaf-curling moth, summer fruit tortrix moth, shimmering adoxophyes moth, bell moth / orange tip moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5529,7 +5529,7 @@
   },
   {
     "root": "LFPF",
-    "refers": "\"TORTRICID (a.k.a. TORTRIX or LEAFROLLER) MOTH\" VI",
+    "refers": "“TORTRICID (a.k.a. TORTRIX or LEAFROLLER) MOTH” VI",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(genus Taniva) spruce needleminer moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5601,7 +5601,7 @@
   },
   {
     "root": "LFPS",
-    "refers": "\"ZYGAENOID MOTH\" I",
+    "refers": "“ZYGAENOID MOTH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Zygaenids; numerous genera) burnet moth, forester moth, smoky moth, skeltonizer moth, vine bud moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5625,7 +5625,7 @@
   },
   {
     "root": "LFPŠ",
-    "refers": "\"ZYGAENOID MOTH\" II",
+    "refers": "“ZYGAENOID MOTH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Dalcerids, Limacodids; numerous genera) slug moth / cup moth, jewel caterpillar moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5649,7 +5649,7 @@
   },
   {
     "root": "LFPĻ",
-    "refers": "\"GELECHIOID MOTH\" I",
+    "refers": "“GELECHIOID MOTH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Gelechioids other than Gelechiids; numerous genera) gelechioid moth / curved-horn moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5673,7 +5673,7 @@
   },
   {
     "root": "LFPĻW",
-    "refers": "\"GELECHIOID MOTH\" II",
+    "refers": "“GELECHIOID MOTH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Elachistids; numerous genera) grass-miner moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5697,7 +5697,7 @@
   },
   {
     "root": "LFPH",
-    "refers": "\"GELECHIOID MOTH\" III",
+    "refers": "“GELECHIOID MOTH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Momphids, numerous genera) mompha moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5721,7 +5721,7 @@
   },
   {
     "root": "LFPHW",
-    "refers": "\"GELECHIOID MOTH\" IV",
+    "refers": "“GELECHIOID MOTH” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Scythridids; numerous genera) flower moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5769,7 +5769,7 @@
   },
   {
     "root": "LFPÇ",
-    "refers": "\"APODITRYSIAN MOTH\" I",
+    "refers": "“APODITRYSIAN MOTH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Carposinids; numerous genera) fruitworm moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5793,7 +5793,7 @@
   },
   {
     "root": "LFPÇW",
-    "refers": "\"APODITRYSIAN MOTH\" II",
+    "refers": "“APODITRYSIAN MOTH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Epermeniids; numerous genera) fringe-tufted moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5817,7 +5817,7 @@
   },
   {
     "root": "LFPSW",
-    "refers": "\"APODITRYSIAN MOTH\" III",
+    "refers": "“APODITRYSIAN MOTH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Choreutids; numerous genera) metalmark moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5841,7 +5841,7 @@
   },
   {
     "root": "LFPSY",
-    "refers": "\"APODITRYSIAN MOTH\" IV",
+    "refers": "“APODITRYSIAN MOTH” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Prodidactid; genus Prodidactis) prodidactis moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5865,7 +5865,7 @@
   },
   {
     "root": "LKW",
-    "refers": "\"PAPILIONID (SWALLOWTAIL) BUTTERFLY\" I",
+    "refers": "“PAPILIONID (SWALLOWTAIL) BUTTERFLY” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Parnassiines; several genera) snow Apollo, mountain Apollo, false Apollo, souther festoon, eastern festoon, Spanish festoon, Bhutan glory, luehdorfina**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5889,7 +5889,7 @@
   },
   {
     "root": "LKY",
-    "refers": "\"HESPERIID (SKIPPER) BUTTERFLY\" I",
+    "refers": "“HESPERIID (SKIPPER) BUTTERFLY” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Coeliadines; several genera) awl, awlet, policeman, African giant skipper**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5913,7 +5913,7 @@
   },
   {
     "root": "LKL",
-    "refers": "\"HESPERIID (SKIPPER) BUTTERFLY\" II",
+    "refers": "“HESPERIID (SKIPPER) BUTTERFLY” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Pyrigines; numerous genera) spread-winged skipper, firetail skipper**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5937,7 +5937,7 @@
   },
   {
     "root": "LKR",
-    "refers": "\"HESPERIID (SKIPPER) BUTTERFLY\" III",
+    "refers": "“HESPERIID (SKIPPER) BUTTERFLY” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Megathymines; several genera) giant skipper**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5961,7 +5961,7 @@
   },
   {
     "root": "LKŘ",
-    "refers": "\"PIERID BUTTERFLY\" I",
+    "refers": "“PIERID BUTTERFLY” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Pierines; numerous genera) white butterfly, orange tip, marble, yellow tip, black-tip, sulphur, sawtooth, dotted border, Jezebel, gull, puffin, albatross, blackvein, caper white, Arab, vagrant**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -5985,7 +5985,7 @@
   },
   {
     "root": "LKÇ",
-    "refers": "\"LYCAENID (GOSSAMER-WINGED) BUTTERFLY\" I",
+    "refers": "“LYCAENID (GOSSAMER-WINGED) BUTTERFLY” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Lycaenines; numerous genera) copper butterfly, sapphire butterfly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6009,7 +6009,7 @@
   },
   {
     "root": "LKF",
-    "refers": "\"LYCAENID (GOSSAMER-WINGED) BUTTERFLY\" II",
+    "refers": "“LYCAENID (GOSSAMER-WINGED) BUTTERFLY” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Miletines; numerous genera) harvester, wooly legs, moth butterfly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6057,7 +6057,7 @@
   },
   {
     "root": "LKM",
-    "refers": "\"NYMPHALID (FOUR-FOOTED / BRUSH-FOOTED) BUTTERFLY\" I",
+    "refers": "“NYMPHALID (FOUR-FOOTED / BRUSH-FOOTED) BUTTERFLY” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Nymphalines; numerous genera) tortoiseshell, admiral, mapwing, anglewing, comma, jester, painted lady, tiger beauty, pirate, eggfly, diadem, oakleaf, leaf, malachite, peacock, Fatima, pansy, commodore, blue beauty, buckeye, meadow argus, northern argus, mother-of-pearl butterfly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6081,7 +6081,7 @@
   },
   {
     "root": "LKN",
-    "refers": "\"NYMPHALID (FOUR-FOOTED / BRUSH-FOOTED) BUTTERFLY\" II",
+    "refers": "“NYMPHALID (FOUR-FOOTED / BRUSH-FOOTED) BUTTERFLY” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Cyrestines; genera Cyrestis, Chersonesia, Marpesia) map, maplet, daggerwing butterfly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6105,7 +6105,7 @@
   },
   {
     "root": "LKV",
-    "refers": "\"NYMPHALID (FOUR-FOOTED / BRUSH-FOOTED) BUTTERFLY\" III",
+    "refers": "“NYMPHALID (FOUR-FOOTED / BRUSH-FOOTED) BUTTERFLY” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Heliconiines; numerous generera) acraea, legionnaire, tawny coster, actinote, altinote, bematistes, lacewing, gulf fritillary / passion butterfly, longwing, postman, banded orange / orange tiger, Julia / flame / flambeau, Juliette, scarce bamboo page / longwing dido, leopard, spotted rustic, blotched leopard, cruiser, yeoman, royal Assyrian, rustic, vagrant, fritillary, polka dot**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6129,7 +6129,7 @@
   },
   {
     "root": "LKB",
-    "refers": "\"NYMPHALID (FOUR-FOOTED / BRUSH-FOOTED) BUTTERFLY\" IV",
+    "refers": "“NYMPHALID (FOUR-FOOTED / BRUSH-FOOTED) BUTTERFLY” IV",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Danaini; several genera) cleric, monarch, queen, tiger, glassy tiger, tree-nymph, wood-nymph, Schneider's surprise, blue tiger, crow, paper, mimic queen, magpie butterfly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6153,7 +6153,7 @@
   },
   {
     "root": "LKH",
-    "refers": "\"NYMPHALID (FOUR-FOOTED / BRUSH-FOOTED) BUTTERFLY\" V",
+    "refers": "“NYMPHALID (FOUR-FOOTED / BRUSH-FOOTED) BUTTERFLY” V",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Calinagines; genus Calinaga) freak butterfly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6225,7 +6225,7 @@
   },
   {
     "root": "LKÇW",
-    "refers": "\"OBTECTOMERAN MOTH\" I",
+    "refers": "“OBTECTOMERAN MOTH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Thyridids; numerous genera) picture-winged leaf moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6249,7 +6249,7 @@
   },
   {
     "root": "LKŠW",
-    "refers": "\"OBTECTOMERAN MOTH\" II",
+    "refers": "“OBTECTOMERAN MOTH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Crambids; numerous genera) grass moth, European corn boere / European corn worm moth / European high-flyer, sod grass webworm moth, rice stem borer**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6273,7 +6273,7 @@
   },
   {
     "root": "ŘZB",
-    "refers": "\"BOMBYCOID MOTH\" I",
+    "refers": "“BOMBYCOID MOTH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Bombycids; numerousgenera) silk moth, emperor moth, sphinx moth, silkworm moth, Brahmin moth, true silkmoth / mulberry silkmoth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6297,7 +6297,7 @@
   },
   {
     "root": "ŘZBW",
-    "refers": "\"BOMBYCOID MOTH\" II",
+    "refers": "“BOMBYCOID MOTH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Saturnids; numerous genera) oakworm moth, regal moth, pine-devil moth, splendid royal moth, rosy maple moth, imperial moth, io moth, buck moth, emperor moth, moon moth, tussar moth, comet moth, Polyphemus moth, mopane moth, cecropia math, silkmoth, Hercules moth, Atlas moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6321,7 +6321,7 @@
   },
   {
     "root": "ŘZBY",
-    "refers": "\"BOMBYCOID MOTH\" III",
+    "refers": "“BOMBYCOID MOTH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Eupterotids, Phiditiids, Endromids, Carthaeids; numerous genera) bombycoid moth, dryandra moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6393,7 +6393,7 @@
   },
   {
     "root": "ŘZV",
-    "refers": "\"EREBID MOTH\" I",
+    "refers": "“EREBID MOTH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Erebines; numerous genera) underwing moth, witch moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6417,7 +6417,7 @@
   },
   {
     "root": "ŘZVW",
-    "refers": "\"EREBID MOTH\" II",
+    "refers": "“EREBID MOTH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Herminiines; numerous genera) litter moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6441,7 +6441,7 @@
   },
   {
     "root": "ŘZVY",
-    "refers": "\"EREBID MOTH\" III",
+    "refers": "“EREBID MOTH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Aganaines; several genera) aganaine, tiger moth**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6562,7 +6562,7 @@
   },
   {
     "root": "ŘJŇ",
-    "refers": "\"MECOPTERAN (SCORPIONFLY)\" I",
+    "refers": "“MECOPTERAN (SCORPIONFLY)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Panorpids; several genera) common scorpionfly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6586,7 +6586,7 @@
   },
   {
     "root": "ŘJŇW",
-    "refers": "\"MECOPTERAN (SCORPIONFLY)\" II",
+    "refers": "“MECOPTERAN (SCORPIONFLY)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Bittacids; numerous genera) hangingfly / hanging scorpionfly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6610,7 +6610,7 @@
   },
   {
     "root": "LZGV",
-    "refers": "\"TUPILOMORPHIC FLY (CRANE FLY)\" I",
+    "refers": "“TUPILOMORPHIC FLY (CRANE FLY)” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Tanyderids; several genera) primitive crane fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6634,7 +6634,7 @@
   },
   {
     "root": "LZGḐ",
-    "refers": "\"TUPILOMORPHIC FLY (CRANE FLY)\" II",
+    "refers": "“TUPILOMORPHIC FLY (CRANE FLY)” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Tipulids and Limoniines; numerous genra) crane fly, limoniid crane fly, snow fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6658,7 +6658,7 @@
   },
   {
     "root": "LZG",
-    "refers": "\"CULICOMORPH\" I",
+    "refers": "“CULICOMORPH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Culicids; numerous genera) mosquito**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6682,7 +6682,7 @@
   },
   {
     "root": "LZGW",
-    "refers": "\"CULICOMORPH\" II",
+    "refers": "“CULICOMORPH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Simuliids; numerous genera) black fly / buffalo gnat / turkey gnat / white socks**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6706,7 +6706,7 @@
   },
   {
     "root": "LZGY",
-    "refers": "\"CULICOMORPH\" III",
+    "refers": "“CULICOMORPH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Chironomids; numerous genera) nonbiting midge / lake fly, harlequin fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6754,7 +6754,7 @@
   },
   {
     "root": "LZGL",
-    "refers": "\"BIBIONOMORPH\" I",
+    "refers": "“BIBIONOMORPH” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Bibionids; several genera) march fly / St. Mark's fly, love bug / honeymoon fly / double-headed bug**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6778,7 +6778,7 @@
   },
   {
     "root": "LZGR",
-    "refers": "\"BIBIONOMORPH\" II",
+    "refers": "“BIBIONOMORPH” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Mycetophilids; numerous genera) fungus gnat**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6802,7 +6802,7 @@
   },
   {
     "root": "LZGZ",
-    "refers": "\"BIBIONOMORPH\" III",
+    "refers": "“BIBIONOMORPH” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Rangomaramids; several genera) long-winged fungus gnat**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6946,7 +6946,7 @@
   },
   {
     "root": "LZBL",
-    "refers": "\"ASILOID FLY\" I",
+    "refers": "“ASILOID FLY” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Asilids; numerous genera) robber fly / assassin fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6970,7 +6970,7 @@
   },
   {
     "root": "LZBR",
-    "refers": "\"ASILOID FLY\" II",
+    "refers": "“ASILOID FLY” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Therevids; numerous genera) stiletto fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -6994,7 +6994,7 @@
   },
   {
     "root": "LZBŘ",
-    "refers": "\"ASILOID FLY\" III",
+    "refers": "“ASILOID FLY” III",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Mythicomyiids; numerous genera) mythicomyiid fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -7018,7 +7018,7 @@
   },
   {
     "root": "LZBZ",
-    "refers": "\"EMPIDOID FLY\" I",
+    "refers": "“EMPIDOID FLY” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Empidids; numerous genera) dagger fly / balloon fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -7042,7 +7042,7 @@
   },
   {
     "root": "LZBŽ",
-    "refers": "\"EMPIDOID FLY FLY\" II",
+    "refers": "“EMPIDOID FLY FLY” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Ragadids; seveal genera) ragadid fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -7117,10 +7117,10 @@
     "refers": "SYRPHOID & OTHER ASCHIZATE FLY",
     "stems": [
       {
-        "BSC": "(to be) an animal identified as **(Syrphids; numerous genera) hoverfly / flower fly / syrphid fly, drone fly / \"H-bee\"**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
-        "CTE": "(to be) that which gives a particular animal identified as **(Syrphids; numerous genera) hoverfly / flower fly / syrphid fly, drone fly / \"H-bee\"** its individual identity; the living essence or mental identity of an animal of such kind",
-        "CSV": "(to be) the physical body of an animal identified as **(Syrphids; numerous genera) hoverfly / flower fly / syrphid fly, drone fly / \"H-bee\"**; the corporeal aspect of an animal of such kind",
-        "OBJ": "(to be) an activity engaged in by an animal identified as **(Syrphids; numerous genera) hoverfly / flower fly / syrphid fly, drone fly / \"H-bee\"**; what an animal of such kind is doing; to act (as a particular animal species of such kind does)"
+        "BSC": "(to be) an animal identified as **(Syrphids; numerous genera) hoverfly / flower fly / syrphid fly, drone fly / “H-bee”**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
+        "CTE": "(to be) that which gives a particular animal identified as **(Syrphids; numerous genera) hoverfly / flower fly / syrphid fly, drone fly / “H-bee”** its individual identity; the living essence or mental identity of an animal of such kind",
+        "CSV": "(to be) the physical body of an animal identified as **(Syrphids; numerous genera) hoverfly / flower fly / syrphid fly, drone fly / “H-bee”**; the corporeal aspect of an animal of such kind",
+        "OBJ": "(to be) an activity engaged in by an animal identified as **(Syrphids; numerous genera) hoverfly / flower fly / syrphid fly, drone fly / “H-bee”**; what an animal of such kind is doing; to act (as a particular animal species of such kind does)"
       },
       {
         "BSC": "(to be) an animal identified as **(Pipunculids; numerousgenera) big-headed fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -7138,7 +7138,7 @@
   },
   {
     "root": "LZK",
-    "refers": "\"TEPHRITOID FLY\" I",
+    "refers": "“TEPHRITOID FLY” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Tephritids; numerous genera) [tephritid] fruit fly / small fruit fly / peacock fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -7162,7 +7162,7 @@
   },
   {
     "root": "LZKL",
-    "refers": "\"TEPHRITOID FLY\" II",
+    "refers": "“TEPHRITOID FLY” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Pallopterids; numerous genera) flutter-wing fly / trembling-wing fly / waving-wing fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -7234,7 +7234,7 @@
   },
   {
     "root": "LZKF",
-    "refers": "\"SCIOMYZOID FLY\" I",
+    "refers": "“SCIOMYZOID FLY” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Sciomyzids; numerous genera) marsh fly, snail-killing fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -7258,7 +7258,7 @@
   },
   {
     "root": "LZKV",
-    "refers": "\"SCIOMYZOID FLY\" II",
+    "refers": "“SCIOMYZOID FLY” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Heterocheilids; genus Heterochela) half-bridge fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -7330,7 +7330,7 @@
   },
   {
     "root": "LZKH",
-    "refers": "\"OPOMYZOID FLY\" I",
+    "refers": "“OPOMYZOID FLY” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Agromyzids; numerous genera) leaf-miner fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -7354,7 +7354,7 @@
   },
   {
     "root": "LZKHW",
-    "refers": "\"OPOMYZOID FLY\" II",
+    "refers": "“OPOMYZOID FLY” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Opomyzids; several genera) opomyzid fly, cereal fly, grass fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -7378,7 +7378,7 @@
   },
   {
     "root": "LZKFW",
-    "refers": "\"EPHYDROID FLY\" I",
+    "refers": "“EPHYDROID FLY” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Ephydrids; numerous genera) shore fly, brine fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -7402,7 +7402,7 @@
   },
   {
     "root": "LZKFY",
-    "refers": "\"EPHYDROID FLY\" II",
+    "refers": "“EPHYDROID FLY” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Curtonotids; several genera) quasimodo fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -7426,7 +7426,7 @@
   },
   {
     "root": "LZKFL",
-    "refers": "\"CARNOID FLY\" I",
+    "refers": "“CARNOID FLY” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Carnids; several genera) bird fly / filth fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -7450,7 +7450,7 @@
   },
   {
     "root": "LZKFR",
-    "refers": "\"CARNOID FLY\" II",
+    "refers": "“CARNOID FLY” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Chloropids; numerous genera) frit fly / grass fly, eye gnat / eye fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -7474,7 +7474,7 @@
   },
   {
     "root": "LZKŢ",
-    "refers": "\"OTHER ACALYPTRATE FLY\" I",
+    "refers": "“OTHER ACALYPTRATE FLY” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Conopids; numerous genera) thick-headed fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -7498,7 +7498,7 @@
   },
   {
     "root": "LZKŢW",
-    "refers": "\"OTHER ACALYPTRATE FLY\" II",
+    "refers": "“OTHER ACALYPTRATE FLY” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Paraleucophids; several genera) paraleucophid fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -7594,7 +7594,7 @@
   },
   {
     "root": "LZVL",
-    "refers": "\"OESTROID FLY\" I",
+    "refers": "“OESTROID FLY” I",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Oestrids; numerous genera) botfly / heel fly / warble fly / gadfly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",
@@ -7619,7 +7619,7 @@
   },
   {
     "root": "LZVW",
-    "refers": "\"OESTROID FLY\" II",
+    "refers": "“OESTROID FLY” II",
     "stems": [
       {
         "BSC": "(to be) an animal identified as **(Rhinophorids; numerous genera) woodlouse fly**, as a holistic entity, including its physical/corporeal body and its and mental identity and living essence; to live/be alive (as an animal of such kind)",

--- a/lexicon/7.3.5.json
+++ b/lexicon/7.3.5.json
@@ -219,7 +219,7 @@
         "OBJ": "(to be) a state or activity being undergone or engaged in by a species identified as **(genus Staphylococcus) staphylococcus**, most likely associated with a particular stage of a species's life-cycle (e.g., dormancy as seed, sproutling, budding, in bloom, withering, winter dormancy, etc.)"
       }
     ],
-    "notes": "To name a particular pathogenic disease, **anthrax**, either concatenate the stem 1, **bacillus**, with an appropriate stem from one of the various applicable roots, or add the new ADI affix to the stem.\n\nTo name a particular pathogenic disease, **listeriasis**, either concatenate the stem 2, **listeria**, with an appropriate stem from one of the various applicable roots, or add the new ADI affix to the stem.\n\nTo name a particular pathogenic disease, **staphylococcosis / \"staph\" infection**, either concatenate the stem 3, **staphylococcus**, with an appropriate stem from one of the various applicable roots, or add the new ADI affix to the stem."
+    "notes": "To name a particular pathogenic disease, **anthrax**, either concatenate the stem 1, **bacillus**, with an appropriate stem from one of the various applicable roots, or add the new ADI affix to the stem.\n\nTo name a particular pathogenic disease, **listeriasis**, either concatenate the stem 2, **listeria**, with an appropriate stem from one of the various applicable roots, or add the new ADI affix to the stem.\n\nTo name a particular pathogenic disease, **staphylococcosis / “staph” infection**, either concatenate the stem 3, **staphylococcus**, with an appropriate stem from one of the various applicable roots, or add the new ADI affix to the stem."
   },
   {
     "root": "PFPW",
@@ -244,7 +244,7 @@
         "OBJ": "(to be) a state or activity being undergone or engaged in by a species identified as **(Lactobacillaceae; numerous genera) lactobacillaceous bacterium [formerly all included in genus Lactobacillus]**, most likely associated with a particular stage of a species's life-cycle (e.g., dormancy as seed, sproutling, budding, in bloom, withering, winter dormancy, etc.)"
       }
     ],
-    "notes": "To name a particular pathogenic disease, **urinary tract infection**, either concatenate the stem 1, **enterococcus**, with an appropriate stem from one of the various applicable roots, or add the new ADI affix to the stem.\n\nTo name a particular pathogenic disease, **\"strep\" infection, pneumococcal infection, scarlet fever, rheumatic fever**, either concatenate the stem 2, **streptococcus**, with an appropriate stem from one of the various applicable roots, or add the new ADI affix to the stem."
+    "notes": "To name a particular pathogenic disease, **urinary tract infection**, either concatenate the stem 1, **enterococcus**, with an appropriate stem from one of the various applicable roots, or add the new ADI affix to the stem.\n\nTo name a particular pathogenic disease, **“strep” infection, pneumococcal infection, scarlet fever, rheumatic fever**, either concatenate the stem 2, **streptococcus**, with an appropriate stem from one of the various applicable roots, or add the new ADI affix to the stem."
   },
   {
     "root": "PFPY",
@@ -1158,10 +1158,10 @@
     "refers": "ARCHAEON",
     "stems": [
       {
-        "BSC": "(to be) a species identified as **(\"DPANN\" Archaea; numerous genera) DPANN archaeon**, as a holistic entity, including its physical/corporeal body and its living essence; to live/be alive (as such a species)",
-        "CTE": "(to be) that which gives a particular species identified as **(\"DPANN\" Archaea; numerous genera) DPANN archaeon** its individual identity; the living essence of such a species",
-        "CSV": "(to be) the physical body of a species identified as **(\"DPANN\" Archaea; numerous genera) DPANN archaeon**; the corporeal aspect of such a species",
-        "OBJ": "(to be) a state or activity being undergone or engaged in by a species identified as **(\"DPANN\" Archaea; numerous genera) DPANN archaeon**, most likely associated with a particular stage of a species's life-cycle (e.g., dormancy as seed, sproutling, budding, in bloom, withering, winter dormancy, etc.)"
+        "BSC": "(to be) a species identified as **(“DPANN” Archaea; numerous genera) DPANN archaeon**, as a holistic entity, including its physical/corporeal body and its living essence; to live/be alive (as such a species)",
+        "CTE": "(to be) that which gives a particular species identified as **(“DPANN” Archaea; numerous genera) DPANN archaeon** its individual identity; the living essence of such a species",
+        "CSV": "(to be) the physical body of a species identified as **(“DPANN” Archaea; numerous genera) DPANN archaeon**; the corporeal aspect of such a species",
+        "OBJ": "(to be) a state or activity being undergone or engaged in by a species identified as **(“DPANN” Archaea; numerous genera) DPANN archaeon**, most likely associated with a particular stage of a species's life-cycle (e.g., dormancy as seed, sproutling, budding, in bloom, withering, winter dormancy, etc.)"
       },
       {
         "BSC": "(to be) a species identified as **(Euryarchaeota; numerous genera) euryarchaeotic archaeon**, as a holistic entity, including its physical/corporeal body and its living essence; to live/be alive (as such a species)",

--- a/lexicon/7.3.6.json
+++ b/lexicon/7.3.6.json
@@ -1328,10 +1328,10 @@
     "refers": "ORTHOMYXOVIRUS (INFLUENZA VIRUS)",
     "stems": [
       {
-        "BSC": "(to be) a species identified as **(genus Alphainfluenzavirus) influenza A virus, avian influenza virus / \"bird flu\" virus**, as a holistic entity, including its physical/corporeal body and its living essence; to live/be alive (as such a species)",
-        "CTE": "(to be) that which gives a particular species identified as **(genus Alphainfluenzavirus) influenza A virus, avian influenza virus / \"bird flu\" virus** its individual identity; the living essence of such a species",
-        "CSV": "(to be) the physical body of a species identified as **(genus Alphainfluenzavirus) influenza A virus, avian influenza virus / \"bird flu\" virus**; the corporeal aspect of such a species",
-        "OBJ": "(to be) a state or activity being undergone or engaged in by a species identified as **(genus Alphainfluenzavirus) influenza A virus, avian influenza virus / \"bird flu\" virus**, most likely associated with a particular stage of a species's life-cycle (e.g., dormancy as seed, sproutling, budding, in bloom, withering, winter dormancy, etc.)"
+        "BSC": "(to be) a species identified as **(genus Alphainfluenzavirus) influenza A virus, avian influenza virus / “bird flu” virus**, as a holistic entity, including its physical/corporeal body and its living essence; to live/be alive (as such a species)",
+        "CTE": "(to be) that which gives a particular species identified as **(genus Alphainfluenzavirus) influenza A virus, avian influenza virus / “bird flu” virus** its individual identity; the living essence of such a species",
+        "CSV": "(to be) the physical body of a species identified as **(genus Alphainfluenzavirus) influenza A virus, avian influenza virus / “bird flu” virus**; the corporeal aspect of such a species",
+        "OBJ": "(to be) a state or activity being undergone or engaged in by a species identified as **(genus Alphainfluenzavirus) influenza A virus, avian influenza virus / “bird flu” virus**, most likely associated with a particular stage of a species's life-cycle (e.g., dormancy as seed, sproutling, budding, in bloom, withering, winter dormancy, etc.)"
       },
       {
         "BSC": "(to be) a species identified as **(genus Betainfluenzavirus) influenza B virus**, as a holistic entity, including its physical/corporeal body and its living essence; to live/be alive (as such a species)",
@@ -1346,7 +1346,7 @@
         "OBJ": "(to be) a state or activity being undergone or engaged in by a species identified as **(genera Gammainfluenzavirus, Deltainfluenzavirus) influenza C virus, influenza D virus**, most likely associated with a particular stage of a species's life-cycle (e.g., dormancy as seed, sproutling, budding, in bloom, withering, winter dormancy, etc.)"
       }
     ],
-    "notes": "To name a particular pathogenic disease, **influenza / \"the flu\"**, either concatenate the stem 1, **nfluenza A virus**, 2, **influenza B virus**, or 3, **influenza C virus**, with an appropriate stem from one of the various applicable roots, or add the new ADI affix to the stem."
+    "notes": "To name a particular pathogenic disease, **influenza / “the flu”**, either concatenate the stem 1, **nfluenza A virus**, 2, **influenza B virus**, or 3, **influenza C virus**, with an appropriate stem from one of the various applicable roots, or add the new ADI affix to the stem."
   },
   {
     "root": "NXPW",

--- a/lexicon/7.3.json
+++ b/lexicon/7.3.json
@@ -91,8 +91,8 @@
     "root": "VN",
     "refers": "BASIC ANIMAL TYPES",
     "stems": [
-      "animal of land or air (\"terroid\")",
-      "waterlife-animal, animal living in water (\"aquoid\")",
+      "animal of land or air (“terroid”)",
+      "waterlife-animal, animal living in water (“aquoid”)",
       "amphibian"
     ],
     "see": "ŠW"
@@ -109,7 +109,7 @@
     "stems": [
       "adult human being",
       "human child",
-      "adolescent human being, \"teenager\""
+      "adolescent human being, “teenager”"
     ],
     "see": "ŠW"
   },
@@ -218,7 +218,7 @@
     "stems": [
       "beetle or beetle-like insect (in terms of appearance/behavior)",
       "ant or ant-like insect (in terms of behavior/appearance)",
-      "rounded \"bug\"-like insect other than beetle (e.g., bed bug, stink bug, junebug, etc.)"
+      "rounded “bug”-like insect other than beetle (e.g., bed bug, stink bug, junebug, etc.)"
     ],
     "see": "ŠW"
   },
@@ -297,7 +297,7 @@
         "OBJ": "(to be) a cocoon or chrysalis"
       },
       {
-        "BSC": "(to be) the \"birth\" or hatching of a life-form from a cocoon, chrysalis, external (shell-bearing) egg, or other interim metamorphic life-stage; to hatch, emerge from a cocoon, emerge from a marsupial pouch, etc.",
+        "BSC": "(to be) the “birth” or hatching of a life-form from a cocoon, chrysalis, external (shell-bearing) egg, or other interim metamorphic life-stage; to hatch, emerge from a cocoon, emerge from a marsupial pouch, etc.",
         "CTE": "(to be) the state of having completed a metamorphic life-stage and becoming one's final corporeal form",
         "CSV": "(to be) the process of hatching/emerging itself",
         "OBJ": "(to be) the discarded cocoon, egg-casing, bud, etc. emerged from"


### PR DESCRIPTION
This PR is out of @ryanlo713's suggestion.

According to [Wikipedia](https://en.wikipedia.org/wiki/Quotation_mark#In_English):

> Regarding their appearance, there are two types of quotation marks:
>
> - '…' and "…" are known as neutral, vertical, straight, typewriter, dumb, or ASCII quotation marks. The left and right marks are identical. These are found on typical English typewriters and computer keyboards, although they are sometimes automatically converted to the other type by software.
> - ‘…’ and “…” are known as typographic, curly, curved, book, or smart quotation marks. (The doubled ones are more informally known as "66 and 99". The beginning marks are commas raised to the top of the line and rotated 180 degrees. The ending marks are commas raised to the top of the line. Curved quotation marks are used mainly in manuscript, printing, and typesetting. Type cases (of any language) generally have the curved quotation mark metal types for the respective language, and may lack the vertical quotation mark metal types. Because most computer keyboards lack keys to enter typographic quotation marks directly, much that is written using word-processing programs has vertical quotation marks. The "smart quotes" feature in some computer software can convert vertical quotation marks to curly ones, although sometimes imperfectly.